### PR TITLE
Add goal-conditioned learned history compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist
 .DS_Store
 wandb
 output
+outputs
 work_dirs
 data
 model_zoo
@@ -34,4 +35,3 @@ ckpts*
 
 # DevContainer
 !.devcontainer/*
-

--- a/offline_eval_uninavid.py
+++ b/offline_eval_uninavid.py
@@ -291,6 +291,7 @@ if __name__ == '__main__':
     h,w,n = images[0].shape
         
     result_vis_list = []
+    result_log = []
     step_count = 0
     for i, img in enumerate(images):
         image=img
@@ -304,9 +305,18 @@ if __name__ == '__main__':
         
         traj = result['path'][0]
         actions = result['actions']
+        result_log.append({
+            "step": step_count,
+            "image": f"images/{i}.jpg",
+            "instruction": instruction,
+            "actions": actions,
+            "trajectory": traj,
+        })
 
         vis = draw_traj_arrows_fpv(img, actions, arrow_len=20)
         result_vis_list.append(vis)
 
     
     imageio.mimsave(os.path.join(args.output_dir,"result.gif"), result_vis_list)
+    with open(os.path.join(args.output_dir, "result.json"), "w", encoding="utf-8") as f:
+        json.dump(result_log, f, ensure_ascii=False, indent=2)

--- a/results/task4_micro_overfit_20.md
+++ b/results/task4_micro_overfit_20.md
@@ -1,0 +1,70 @@
+# Task 4: 20-sample micro-overfit diagnostic
+
+## Question
+
+Can a one-layer goal-conditioned history compressor memorize a small dataset on
+its own, or does the fixed multimodal projector constrain it?
+
+## Setup
+
+- 20 training samples: 5 from each history-length bin
+- Goals: chair and toilet
+- History range: 20 to 272 frames
+- Cross-Attention decoder: 1 layer, 64 output queries, dropout 0
+- Video augmentation: disabled
+- Optimization: 1000 steps (50 epochs), constant learning rate `3e-4`
+- LLM and vision encoder: frozen in both runs
+- Evaluation: teacher-forced on the same 20 training samples
+
+Run A trained only the history compressor and goal projector. Run B also trained
+the existing `mm_projector`, which maps compressed and current-frame vision
+features into the frozen LLM embedding space.
+
+## Results
+
+| Metric | A: compressor only | B: compressor + mm_projector |
+| --- | ---: | ---: |
+| Evaluation loss | 0.3751 | 0.0060 |
+| Mean action accuracy | 83.75% | 100.0% |
+| First action accuracy | 80.0% | 100.0% |
+| Four-action exact match | 50.0% | 100.0% |
+| Last logged train loss | 0.4621 | 0.0378 |
+| Minimum logged train loss | 0.3134 | 0.0001 |
+
+Run B reached 100% four-action exact match in every history-length bin. Its saved
+adapter contains 36 history-compressor tensors and 4 multimodal-projector tensors,
+with no LLM or vision-encoder weights.
+
+## Conclusion
+
+One Cross-Attention layer has enough capacity to memorize this diagnostic set.
+The fixed `mm_projector` was the limiting interface: training it alongside the
+compressor changed exact match from 50% to 100%. This does not establish
+generalization because the evaluation uses the training samples with teacher
+forcing.
+
+The next controlled experiment should train the compressor and `mm_projector` on
+the 200-sample subset, then compare it with the compressor-only 2000-step result
+and the heuristic baseline. LoRA on the LLM is not yet justified by this result.
+
+## Commands
+
+The subset was generated with:
+
+```bash
+.venv/bin/python tools/build_task4_subset.py \
+  --samples-json /home/novel/uninavid-data/task4_uninavid_full/samples_train.json \
+  --stock-json /home/novel/uninavid-data/task4_uninavid_full/uninavid_train_goal.json \
+  --output /home/novel/uninavid-data/task4_uninavid_full/task4_micro_overfit_20_goal.json \
+  --per-bin 5 \
+  --seed 42
+```
+
+Both runs used `scripts/task4_overfit_200_goal.sh`. Run B added:
+
+```bash
+TUNE_MM_MLP_ADAPTER=True
+```
+
+Machine-readable metrics are in
+`results/task4_micro_overfit_20_projector_comparison.json`.

--- a/results/task4_micro_overfit_20_projector_comparison.json
+++ b/results/task4_micro_overfit_20_projector_comparison.json
@@ -1,0 +1,206 @@
+{
+  "manifest": "/home/novel/uninavid-data/task4_uninavid_full/task4_micro_overfit_20_goal.json",
+  "teacher_forced": true,
+  "baseline_mode": "goal_cross_attention",
+  "candidate_mode": "goal_cross_attention",
+  "baseline": {
+    "samples": 20,
+    "loss": 0.3751220703125,
+    "action_accuracy": [
+      0.8,
+      0.85,
+      0.95,
+      0.75
+    ],
+    "first_action_accuracy": 0.8,
+    "four_action_exact_match": 0.5,
+    "mean_action_accuracy": 0.8374999999999999
+  },
+  "candidate": {
+    "samples": 20,
+    "loss": 0.006022021174430847,
+    "action_accuracy": [
+      1.0,
+      1.0,
+      1.0,
+      1.0
+    ],
+    "first_action_accuracy": 1.0,
+    "four_action_exact_match": 1.0,
+    "mean_action_accuracy": 1.0
+  },
+  "candidate_minus_baseline": {
+    "loss": -0.36910004913806915,
+    "action_accuracy": [
+      0.19999999999999996,
+      0.15000000000000002,
+      0.050000000000000044,
+      0.25
+    ],
+    "mean_action_accuracy": 0.1625000000000001,
+    "first_action_accuracy": 0.19999999999999996,
+    "four_action_exact_match": 0.5
+  },
+  "by_history_bin": {
+    "extra_long": {
+      "baseline": {
+        "samples": 5,
+        "loss": 0.30458984375,
+        "action_accuracy": [
+          1.0,
+          0.8,
+          1.0,
+          0.8
+        ],
+        "first_action_accuracy": 1.0,
+        "four_action_exact_match": 0.6,
+        "mean_action_accuracy": 0.8999999999999999
+      },
+      "candidate": {
+        "samples": 5,
+        "loss": 0.009584522247314453,
+        "action_accuracy": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "first_action_accuracy": 1.0,
+        "four_action_exact_match": 1.0,
+        "mean_action_accuracy": 1.0
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.29500532150268555,
+        "action_accuracy": [
+          0.0,
+          0.19999999999999996,
+          0.0,
+          0.19999999999999996
+        ],
+        "mean_action_accuracy": 0.10000000000000009,
+        "first_action_accuracy": 0.0,
+        "four_action_exact_match": 0.4
+      }
+    },
+    "long": {
+      "baseline": {
+        "samples": 5,
+        "loss": 0.4125,
+        "action_accuracy": [
+          0.6,
+          0.8,
+          1.0,
+          0.8
+        ],
+        "first_action_accuracy": 0.6,
+        "four_action_exact_match": 0.4,
+        "mean_action_accuracy": 0.8
+      },
+      "candidate": {
+        "samples": 5,
+        "loss": 0.010129928588867188,
+        "action_accuracy": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "first_action_accuracy": 1.0,
+        "four_action_exact_match": 1.0,
+        "mean_action_accuracy": 1.0
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.4023700714111328,
+        "action_accuracy": [
+          0.4,
+          0.19999999999999996,
+          0.0,
+          0.19999999999999996
+        ],
+        "mean_action_accuracy": 0.19999999999999996,
+        "first_action_accuracy": 0.4,
+        "four_action_exact_match": 0.6
+      }
+    },
+    "medium": {
+      "baseline": {
+        "samples": 5,
+        "loss": 0.5439453125,
+        "action_accuracy": [
+          0.6,
+          0.8,
+          1.0,
+          0.6
+        ],
+        "first_action_accuracy": 0.6,
+        "four_action_exact_match": 0.4,
+        "mean_action_accuracy": 0.75
+      },
+      "candidate": {
+        "samples": 5,
+        "loss": 0.00012481212615966797,
+        "action_accuracy": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "first_action_accuracy": 1.0,
+        "four_action_exact_match": 1.0,
+        "mean_action_accuracy": 1.0
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.5438205003738403,
+        "action_accuracy": [
+          0.4,
+          0.19999999999999996,
+          0.0,
+          0.4
+        ],
+        "mean_action_accuracy": 0.25,
+        "first_action_accuracy": 0.4,
+        "four_action_exact_match": 0.6
+      }
+    },
+    "short": {
+      "baseline": {
+        "samples": 5,
+        "loss": 0.239453125,
+        "action_accuracy": [
+          1.0,
+          1.0,
+          0.8,
+          0.8
+        ],
+        "first_action_accuracy": 1.0,
+        "four_action_exact_match": 0.6,
+        "mean_action_accuracy": 0.8999999999999999
+      },
+      "candidate": {
+        "samples": 5,
+        "loss": 0.00424882173538208,
+        "action_accuracy": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "first_action_accuracy": 1.0,
+        "four_action_exact_match": 1.0,
+        "mean_action_accuracy": 1.0
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.23520430326461791,
+        "action_accuracy": [
+          0.0,
+          0.0,
+          0.19999999999999996,
+          0.19999999999999996
+        ],
+        "mean_action_accuracy": 0.10000000000000009,
+        "first_action_accuracy": 0.0,
+        "four_action_exact_match": 0.4
+      }
+    }
+  }
+}

--- a/results/task4_overfit_200.md
+++ b/results/task4_overfit_200.md
@@ -103,3 +103,89 @@ LR_SCHEDULER_TYPE=constant \
 
 Machine-readable follow-up metrics are in
 `results/task4_overfit_200_1layer_2000_comparison.json`.
+
+## Follow-up: jointly train the multimodal projector
+
+The next controlled run kept the one-layer, 2000-step configuration and also
+trained the existing multimodal projector:
+
+- Cross-Attention decoder layers: 1
+- Dropout: 0
+- Video augmentation: disabled
+- Learning rate: constant `3e-4`, no warmup
+- Training: 2000 steps (10 epochs)
+- Trainable parameters: history compressor, goal projector, and `mm_projector`
+
+The saved adapter contains 36 history-compressor tensors and 4 multimodal-
+projector tensors, with no LLM or vision-encoder weights. Mean logged loss by
+epoch decreased from 0.8368 in epoch 1 to 0.7130 in epoch 10, but evaluation was
+worse than both comparison methods.
+
+| Metric | Heuristic | Compressor only | Compressor + projector |
+| --- | ---: | ---: | ---: |
+| Loss | 0.7073 | 0.5637 | 0.7072 |
+| Mean action accuracy | 62.625% | 68.0% | 56.5% |
+| First action accuracy | 59.0% | 60.0% | 51.5% |
+| Four-action exact match | 17.0% | 18.0% | 8.5% |
+
+Jointly updating the projector at the same `3e-4` learning rate did not reproduce
+the 20-sample memorization result at 200 samples. The projector is shared by the
+compressed history and the uncompressed current frame, so changing it can also
+damage the pretrained current-frame interface. A useful next diagnostic is to
+use separate learning rates: keep the compressor at `3e-4` and update the
+projector conservatively, for example at `1e-5`, preferably from the successful
+compressor-only checkpoint. Adding Q-Former depth or LLM LoRA is not justified
+until this interface effect is isolated.
+
+Machine-readable metrics are in
+`results/task4_overfit_200_with_projector_comparison.json`.
+
+## Follow-up: lower learning rate for the multimodal projector
+
+The final controlled run used separate optimizer groups while keeping all other
+settings unchanged:
+
+- History compressor learning rate: constant `3e-4`
+- Multimodal projector learning rate: constant `1e-5`
+- Cross-Attention decoder layers: 1
+- Dropout: 0
+- Video augmentation: disabled
+- Training: 2000 steps (10 epochs), seed 42
+
+Mean logged loss decreased monotonically by epoch from 0.7173 to 0.5109. The
+aggregate train loss was 0.6030, and the minimum logged 10-step loss was 0.2987.
+
+| Metric | Heuristic | Compressor only | Projector at `3e-4` | Projector at `1e-5` |
+| --- | ---: | ---: | ---: | ---: |
+| Loss | 0.7073 | 0.5637 | 0.7072 | **0.4629** |
+| Mean action accuracy | 62.625% | 68.0% | 56.5% | **77.5%** |
+| First action accuracy | 59.0% | 60.0% | 51.5% | **76.0%** |
+| Four-action exact match | 17.0% | 18.0% | 8.5% | **41.0%** |
+
+The lower projector learning rate improved mean action accuracy by 9.5 points
+and exact match by 23 points over the compressor-only run. This supports the
+interface-damage hypothesis: the projector benefits from adaptation, but its
+pretrained mapping is damaged when it is updated at the compressor's learning
+rate. The run still falls short of the 95% memorization target and remains a
+teacher-forced evaluation on training samples. The next step is a longer
+low-projector-LR overfit run or checkpointed evaluation before moving to held-out
+episodes.
+
+The run used:
+
+```bash
+OUTPUT_DIR=outputs/task4-overfit-200-projector-lr1e-5 \
+MAX_STEPS=2000 \
+HISTORY_NUM_LAYERS=1 \
+HISTORY_DROPOUT=0 \
+VIDEO_AUGMENTATION=False \
+LEARNING_RATE=3e-4 \
+WARMUP_RATIO=0 \
+LR_SCHEDULER_TYPE=constant \
+TUNE_MM_MLP_ADAPTER=True \
+LR_MULTI='mm_projector:0.03333333333333333' \
+./scripts/task4_overfit_200_goal.sh
+```
+
+Machine-readable metrics are in
+`results/task4_overfit_200_projector_lr1e-5_comparison.json`.

--- a/results/task4_overfit_200.md
+++ b/results/task4_overfit_200.md
@@ -54,3 +54,52 @@ budget before claiming an improvement, then validate on held-out episodes and
 online rollouts.
 
 Machine-readable metrics are in `results/task4_overfit_200_comparison.json`.
+
+## Follow-up: one layer and 2000 steps
+
+The follow-up run changed only the optimization and compressor-depth settings:
+
+- Cross-Attention decoder layers: 1
+- Dropout: 0
+- Video augmentation: disabled
+- Learning rate: constant `3e-4`, no warmup
+- Training: 2000 steps (10 epochs)
+
+The mean logged loss by epoch decreased monotonically from 1.0115 to 0.5771.
+Aggregate train loss was 0.6564. This confirms that the one-layer compressor can
+learn, but it still did not memorize the 200 samples.
+
+| Metric | Heuristic | 2 layers, 400 steps | 1 layer, 2000 steps |
+| --- | ---: | ---: | ---: |
+| Loss | 0.7073 | 0.6672 | 0.5637 |
+| Mean action accuracy | 62.625% | 62.625% | 68.0% |
+| First action accuracy | 59.0% | 57.5% | 60.0% |
+| Four-action exact match | 17.0% | 13.0% | 18.0% |
+
+Compared with the heuristic, the one-layer run improved mean action accuracy by
+5.375 percentage points and exact match by 1 point. The largest mean action
+accuracy gains were in the medium (+8.0 points) and long (+7.5 points) history
+bins. Exact match improved only in the medium bin; it fell in the other three
+bins.
+
+This supports using one layer for the next diagnostic experiment. It does not
+show that one layer is sufficient for the final model: 18% exact match is far
+below the 95% memorization target, and this remains a teacher-forced evaluation
+on the training samples.
+
+The follow-up command was:
+
+```bash
+OUTPUT_DIR=outputs/task4-overfit-200-goal-1layer-2000 \
+MAX_STEPS=2000 \
+HISTORY_NUM_LAYERS=1 \
+HISTORY_DROPOUT=0 \
+VIDEO_AUGMENTATION=False \
+LEARNING_RATE=3e-4 \
+WARMUP_RATIO=0 \
+LR_SCHEDULER_TYPE=constant \
+./scripts/task4_overfit_200_goal.sh
+```
+
+Machine-readable follow-up metrics are in
+`results/task4_overfit_200_1layer_2000_comparison.json`.

--- a/results/task4_overfit_200.md
+++ b/results/task4_overfit_200.md
@@ -1,0 +1,56 @@
+# Task 4 goal-conditioned history compression: 200-sample overfit check
+
+## Setup
+
+- Date: 2026-07-19
+- Branch: `learned-history-compressor`
+- Training set: 200 samples, stratified into 50 samples for each history bin
+- History input: 8 x 8 = 64 tokens per frame, up to 320 observed frames
+- Learned output: 64 fixed history tokens; the current frame remains separate
+- Goal input: frozen Llama token embeddings, masked mean pooling, trainable goal projector
+- Trainable parameters: history compressor and goal projector only
+- Training: 400 steps (2 epochs), batch size 1, cosine learning rate from `1e-4`
+- Evaluation: teacher-forced on the same 200 training samples, with video augmentation disabled
+
+This is a pipeline and memorization check. It is not a held-out navigation or
+online rollout evaluation.
+
+## Training result
+
+- Aggregate train loss: 0.7263
+- First logged 10-step loss: 0.9671
+- Step-200 10-step loss: 0.6953
+- Final 10-step loss: 0.9165
+- Best logged 10-step loss: 0.5530 at step 320
+
+Loss decreased in several intervals, but the run did not completely memorize the
+200 samples.
+
+## Teacher-forced comparison
+
+| Metric | Heuristic | Goal Cross-Attention | Difference |
+| --- | ---: | ---: | ---: |
+| Loss | 0.7073 | 0.6672 | -0.0401 |
+| Mean action accuracy | 62.625% | 62.625% | 0.000 pp |
+| First action accuracy | 59.0% | 57.5% | -1.5 pp |
+| Four-action exact match | 17.0% | 13.0% | -4.0 pp |
+
+Action accuracy by target position:
+
+| Position | Heuristic | Goal Cross-Attention | Difference |
+| --- | ---: | ---: | ---: |
+| 1 | 59.0% | 57.5% | -1.5 pp |
+| 2 | 63.0% | 64.0% | +1.0 pp |
+| 3 | 67.0% | 70.0% | +3.0 pp |
+| 4 | 61.5% | 59.0% | -2.5 pp |
+
+## Conclusion
+
+The learned compressor reduced teacher-forced loss by 0.0401, but it did not
+beat the heuristic baseline on mean action accuracy or exact match after 400
+steps. Step 8 is therefore complete as an experiment, with a negative accuracy
+result. The next experiment should change the optimization schedule or training
+budget before claiming an improvement, then validate on held-out episodes and
+online rollouts.
+
+Machine-readable metrics are in `results/task4_overfit_200_comparison.json`.

--- a/results/task4_overfit_200_1layer_2000_comparison.json
+++ b/results/task4_overfit_200_1layer_2000_comparison.json
@@ -1,0 +1,206 @@
+{
+  "manifest": "/home/novel/uninavid-data/task4_uninavid_full/task4_overfit_200_goal.json",
+  "teacher_forced": true,
+  "baseline_mode": "heuristic",
+  "candidate_mode": "goal_cross_attention",
+  "baseline": {
+    "samples": 200,
+    "loss": 0.7073091697692871,
+    "action_accuracy": [
+      0.59,
+      0.63,
+      0.67,
+      0.615
+    ],
+    "first_action_accuracy": 0.59,
+    "four_action_exact_match": 0.17,
+    "mean_action_accuracy": 0.62625
+  },
+  "candidate": {
+    "samples": 200,
+    "loss": 0.563681640625,
+    "action_accuracy": [
+      0.6,
+      0.69,
+      0.72,
+      0.71
+    ],
+    "first_action_accuracy": 0.6,
+    "four_action_exact_match": 0.18,
+    "mean_action_accuracy": 0.6799999999999999
+  },
+  "candidate_minus_baseline": {
+    "loss": -0.1436275291442871,
+    "action_accuracy": [
+      0.010000000000000009,
+      0.05999999999999994,
+      0.04999999999999993,
+      0.09499999999999997
+    ],
+    "mean_action_accuracy": 0.053749999999999964,
+    "first_action_accuracy": 0.010000000000000009,
+    "four_action_exact_match": 0.009999999999999981
+  },
+  "by_history_bin": {
+    "extra_long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.61771484375,
+        "action_accuracy": [
+          0.68,
+          0.82,
+          0.7,
+          0.66
+        ],
+        "first_action_accuracy": 0.68,
+        "four_action_exact_match": 0.22,
+        "mean_action_accuracy": 0.7150000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.47158203125,
+        "action_accuracy": [
+          0.66,
+          0.8,
+          0.74,
+          0.72
+        ],
+        "first_action_accuracy": 0.66,
+        "four_action_exact_match": 0.2,
+        "mean_action_accuracy": 0.73
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.1461328125,
+        "action_accuracy": [
+          -0.020000000000000018,
+          -0.019999999999999907,
+          0.040000000000000036,
+          0.05999999999999994
+        ],
+        "mean_action_accuracy": 0.014999999999999902,
+        "first_action_accuracy": -0.020000000000000018,
+        "four_action_exact_match": -0.01999999999999999
+      }
+    },
+    "long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.73099609375,
+        "action_accuracy": [
+          0.56,
+          0.44,
+          0.64,
+          0.62
+        ],
+        "first_action_accuracy": 0.56,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.5650000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.617890625,
+        "action_accuracy": [
+          0.58,
+          0.6,
+          0.72,
+          0.66
+        ],
+        "first_action_accuracy": 0.58,
+        "four_action_exact_match": 0.12,
+        "mean_action_accuracy": 0.64
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.11310546874999994,
+        "action_accuracy": [
+          0.019999999999999907,
+          0.15999999999999998,
+          0.07999999999999996,
+          0.040000000000000036
+        ],
+        "mean_action_accuracy": 0.07499999999999996,
+        "first_action_accuracy": 0.019999999999999907,
+        "four_action_exact_match": -0.020000000000000018
+      }
+    },
+    "medium": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.6939632415771484,
+        "action_accuracy": [
+          0.58,
+          0.6,
+          0.7,
+          0.62
+        ],
+        "first_action_accuracy": 0.58,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.625
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.5867578125,
+        "action_accuracy": [
+          0.64,
+          0.74,
+          0.74,
+          0.7
+        ],
+        "first_action_accuracy": 0.64,
+        "four_action_exact_match": 0.28,
+        "mean_action_accuracy": 0.7050000000000001
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.10720542907714836,
+        "action_accuracy": [
+          0.06000000000000005,
+          0.14,
+          0.040000000000000036,
+          0.07999999999999996
+        ],
+        "mean_action_accuracy": 0.08000000000000007,
+        "first_action_accuracy": 0.06000000000000005,
+        "four_action_exact_match": 0.14
+      }
+    },
+    "short": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.7865625,
+        "action_accuracy": [
+          0.54,
+          0.66,
+          0.64,
+          0.56
+        ],
+        "first_action_accuracy": 0.54,
+        "four_action_exact_match": 0.18,
+        "mean_action_accuracy": 0.6000000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.57849609375,
+        "action_accuracy": [
+          0.52,
+          0.62,
+          0.68,
+          0.76
+        ],
+        "first_action_accuracy": 0.52,
+        "four_action_exact_match": 0.12,
+        "mean_action_accuracy": 0.645
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.20806640625000006,
+        "action_accuracy": [
+          -0.020000000000000018,
+          -0.040000000000000036,
+          0.040000000000000036,
+          0.19999999999999996
+        ],
+        "mean_action_accuracy": 0.04499999999999993,
+        "first_action_accuracy": -0.020000000000000018,
+        "four_action_exact_match": -0.06
+      }
+    }
+  }
+}

--- a/results/task4_overfit_200_comparison.json
+++ b/results/task4_overfit_200_comparison.json
@@ -1,0 +1,206 @@
+{
+  "manifest": "/home/novel/uninavid-data/task4_uninavid_full/task4_overfit_200_goal.json",
+  "teacher_forced": true,
+  "baseline_mode": "heuristic",
+  "candidate_mode": "goal_cross_attention",
+  "baseline": {
+    "samples": 200,
+    "loss": 0.7073091697692871,
+    "action_accuracy": [
+      0.59,
+      0.63,
+      0.67,
+      0.615
+    ],
+    "first_action_accuracy": 0.59,
+    "four_action_exact_match": 0.17,
+    "mean_action_accuracy": 0.62625
+  },
+  "candidate": {
+    "samples": 200,
+    "loss": 0.6672314453125,
+    "action_accuracy": [
+      0.575,
+      0.64,
+      0.7,
+      0.59
+    ],
+    "first_action_accuracy": 0.575,
+    "four_action_exact_match": 0.13,
+    "mean_action_accuracy": 0.62625
+  },
+  "candidate_minus_baseline": {
+    "loss": -0.040077724456787145,
+    "action_accuracy": [
+      -0.015000000000000013,
+      0.010000000000000009,
+      0.029999999999999916,
+      -0.025000000000000022
+    ],
+    "mean_action_accuracy": 0.0,
+    "first_action_accuracy": -0.015000000000000013,
+    "four_action_exact_match": -0.04000000000000001
+  },
+  "by_history_bin": {
+    "extra_long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.61771484375,
+        "action_accuracy": [
+          0.68,
+          0.82,
+          0.7,
+          0.66
+        ],
+        "first_action_accuracy": 0.68,
+        "four_action_exact_match": 0.22,
+        "mean_action_accuracy": 0.7150000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.553046875,
+        "action_accuracy": [
+          0.64,
+          0.78,
+          0.68,
+          0.64
+        ],
+        "first_action_accuracy": 0.64,
+        "four_action_exact_match": 0.12,
+        "mean_action_accuracy": 0.685
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.06466796874999992,
+        "action_accuracy": [
+          -0.040000000000000036,
+          -0.039999999999999925,
+          -0.019999999999999907,
+          -0.020000000000000018
+        ],
+        "mean_action_accuracy": -0.030000000000000027,
+        "first_action_accuracy": -0.040000000000000036,
+        "four_action_exact_match": -0.1
+      }
+    },
+    "long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.73099609375,
+        "action_accuracy": [
+          0.56,
+          0.44,
+          0.64,
+          0.62
+        ],
+        "first_action_accuracy": 0.56,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.5650000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.70150390625,
+        "action_accuracy": [
+          0.58,
+          0.56,
+          0.72,
+          0.6
+        ],
+        "first_action_accuracy": 0.58,
+        "four_action_exact_match": 0.16,
+        "mean_action_accuracy": 0.615
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.029492187499999933,
+        "action_accuracy": [
+          0.019999999999999907,
+          0.12000000000000005,
+          0.07999999999999996,
+          -0.020000000000000018
+        ],
+        "mean_action_accuracy": 0.04999999999999993,
+        "first_action_accuracy": 0.019999999999999907,
+        "four_action_exact_match": 0.01999999999999999
+      }
+    },
+    "medium": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.6939632415771484,
+        "action_accuracy": [
+          0.58,
+          0.6,
+          0.7,
+          0.62
+        ],
+        "first_action_accuracy": 0.58,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.625
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.70625,
+        "action_accuracy": [
+          0.56,
+          0.56,
+          0.7,
+          0.54
+        ],
+        "first_action_accuracy": 0.56,
+        "four_action_exact_match": 0.12,
+        "mean_action_accuracy": 0.5900000000000001
+      },
+      "candidate_minus_baseline": {
+        "loss": 0.012286758422851651,
+        "action_accuracy": [
+          -0.019999999999999907,
+          -0.039999999999999925,
+          0.0,
+          -0.07999999999999996
+        ],
+        "mean_action_accuracy": -0.03499999999999992,
+        "first_action_accuracy": -0.019999999999999907,
+        "four_action_exact_match": -0.020000000000000018
+      }
+    },
+    "short": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.7865625,
+        "action_accuracy": [
+          0.54,
+          0.66,
+          0.64,
+          0.56
+        ],
+        "first_action_accuracy": 0.54,
+        "four_action_exact_match": 0.18,
+        "mean_action_accuracy": 0.6000000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.708125,
+        "action_accuracy": [
+          0.52,
+          0.66,
+          0.7,
+          0.58
+        ],
+        "first_action_accuracy": 0.52,
+        "four_action_exact_match": 0.12,
+        "mean_action_accuracy": 0.615
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.07843750000000005,
+        "action_accuracy": [
+          -0.020000000000000018,
+          0.0,
+          0.05999999999999994,
+          0.019999999999999907
+        ],
+        "mean_action_accuracy": 0.014999999999999902,
+        "first_action_accuracy": -0.020000000000000018,
+        "four_action_exact_match": -0.06
+      }
+    }
+  }
+}

--- a/results/task4_overfit_200_projector_lr1e-5_comparison.json
+++ b/results/task4_overfit_200_projector_lr1e-5_comparison.json
@@ -1,0 +1,206 @@
+{
+  "manifest": "/home/novel/uninavid-data/task4_uninavid_full/task4_overfit_200_goal.json",
+  "teacher_forced": true,
+  "baseline_mode": "heuristic",
+  "candidate_mode": "goal_cross_attention",
+  "baseline": {
+    "samples": 200,
+    "loss": 0.7073091697692871,
+    "action_accuracy": [
+      0.59,
+      0.63,
+      0.67,
+      0.615
+    ],
+    "first_action_accuracy": 0.59,
+    "four_action_exact_match": 0.17,
+    "mean_action_accuracy": 0.62625
+  },
+  "candidate": {
+    "samples": 200,
+    "loss": 0.4628582763671875,
+    "action_accuracy": [
+      0.76,
+      0.76,
+      0.805,
+      0.775
+    ],
+    "first_action_accuracy": 0.76,
+    "four_action_exact_match": 0.41,
+    "mean_action_accuracy": 0.775
+  },
+  "candidate_minus_baseline": {
+    "loss": -0.24445089340209963,
+    "action_accuracy": [
+      0.17000000000000004,
+      0.13,
+      0.135,
+      0.16000000000000003
+    ],
+    "mean_action_accuracy": 0.14875000000000005,
+    "first_action_accuracy": 0.17000000000000004,
+    "four_action_exact_match": 0.23999999999999996
+  },
+  "by_history_bin": {
+    "extra_long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.61771484375,
+        "action_accuracy": [
+          0.68,
+          0.82,
+          0.7,
+          0.66
+        ],
+        "first_action_accuracy": 0.68,
+        "four_action_exact_match": 0.22,
+        "mean_action_accuracy": 0.7150000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.31721923828125,
+        "action_accuracy": [
+          0.78,
+          0.84,
+          0.9,
+          0.84
+        ],
+        "first_action_accuracy": 0.78,
+        "four_action_exact_match": 0.46,
+        "mean_action_accuracy": 0.84
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.30049560546875,
+        "action_accuracy": [
+          0.09999999999999998,
+          0.020000000000000018,
+          0.20000000000000007,
+          0.17999999999999994
+        ],
+        "mean_action_accuracy": 0.12499999999999989,
+        "first_action_accuracy": 0.09999999999999998,
+        "four_action_exact_match": 0.24000000000000002
+      }
+    },
+    "long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.73099609375,
+        "action_accuracy": [
+          0.56,
+          0.44,
+          0.64,
+          0.62
+        ],
+        "first_action_accuracy": 0.56,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.5650000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.597861328125,
+        "action_accuracy": [
+          0.74,
+          0.68,
+          0.74,
+          0.7
+        ],
+        "first_action_accuracy": 0.74,
+        "four_action_exact_match": 0.32,
+        "mean_action_accuracy": 0.7150000000000001
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.13313476562499993,
+        "action_accuracy": [
+          0.17999999999999994,
+          0.24000000000000005,
+          0.09999999999999998,
+          0.07999999999999996
+        ],
+        "mean_action_accuracy": 0.15000000000000002,
+        "first_action_accuracy": 0.17999999999999994,
+        "four_action_exact_match": 0.18
+      }
+    },
+    "medium": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.6939632415771484,
+        "action_accuracy": [
+          0.58,
+          0.6,
+          0.7,
+          0.62
+        ],
+        "first_action_accuracy": 0.58,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.625
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.4714501953125,
+        "action_accuracy": [
+          0.74,
+          0.78,
+          0.82,
+          0.78
+        ],
+        "first_action_accuracy": 0.74,
+        "four_action_exact_match": 0.48,
+        "mean_action_accuracy": 0.78
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.2225130462646484,
+        "action_accuracy": [
+          0.16000000000000003,
+          0.18000000000000005,
+          0.12,
+          0.16000000000000003
+        ],
+        "mean_action_accuracy": 0.15500000000000003,
+        "first_action_accuracy": 0.16000000000000003,
+        "four_action_exact_match": 0.33999999999999997
+      }
+    },
+    "short": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.7865625,
+        "action_accuracy": [
+          0.54,
+          0.66,
+          0.64,
+          0.56
+        ],
+        "first_action_accuracy": 0.54,
+        "four_action_exact_match": 0.18,
+        "mean_action_accuracy": 0.6000000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.46490234375,
+        "action_accuracy": [
+          0.78,
+          0.74,
+          0.76,
+          0.78
+        ],
+        "first_action_accuracy": 0.78,
+        "four_action_exact_match": 0.38,
+        "mean_action_accuracy": 0.7650000000000001
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.32166015625000005,
+        "action_accuracy": [
+          0.24,
+          0.07999999999999996,
+          0.12,
+          0.21999999999999997
+        ],
+        "mean_action_accuracy": 0.16500000000000004,
+        "first_action_accuracy": 0.24,
+        "four_action_exact_match": 0.2
+      }
+    }
+  }
+}

--- a/results/task4_overfit_200_with_projector_comparison.json
+++ b/results/task4_overfit_200_with_projector_comparison.json
@@ -1,0 +1,206 @@
+{
+  "manifest": "/home/novel/uninavid-data/task4_uninavid_full/task4_overfit_200_goal.json",
+  "teacher_forced": true,
+  "baseline_mode": "heuristic",
+  "candidate_mode": "goal_cross_attention",
+  "baseline": {
+    "samples": 200,
+    "loss": 0.7073091697692871,
+    "action_accuracy": [
+      0.59,
+      0.63,
+      0.67,
+      0.615
+    ],
+    "first_action_accuracy": 0.59,
+    "four_action_exact_match": 0.17,
+    "mean_action_accuracy": 0.62625
+  },
+  "candidate": {
+    "samples": 200,
+    "loss": 0.7071533203125,
+    "action_accuracy": [
+      0.515,
+      0.57,
+      0.59,
+      0.585
+    ],
+    "first_action_accuracy": 0.515,
+    "four_action_exact_match": 0.085,
+    "mean_action_accuracy": 0.565
+  },
+  "candidate_minus_baseline": {
+    "loss": -0.00015584945678714934,
+    "action_accuracy": [
+      -0.07499999999999996,
+      -0.06000000000000005,
+      -0.08000000000000007,
+      -0.030000000000000027
+    ],
+    "mean_action_accuracy": -0.06125000000000003,
+    "first_action_accuracy": -0.07499999999999996,
+    "four_action_exact_match": -0.085
+  },
+  "by_history_bin": {
+    "extra_long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.61771484375,
+        "action_accuracy": [
+          0.68,
+          0.82,
+          0.7,
+          0.66
+        ],
+        "first_action_accuracy": 0.68,
+        "four_action_exact_match": 0.22,
+        "mean_action_accuracy": 0.7150000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.689375,
+        "action_accuracy": [
+          0.6,
+          0.68,
+          0.64,
+          0.66
+        ],
+        "first_action_accuracy": 0.6,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.645
+      },
+      "candidate_minus_baseline": {
+        "loss": 0.07166015625,
+        "action_accuracy": [
+          -0.08000000000000007,
+          -0.1399999999999999,
+          -0.05999999999999994,
+          0.0
+        ],
+        "mean_action_accuracy": -0.07000000000000006,
+        "first_action_accuracy": -0.08000000000000007,
+        "four_action_exact_match": -0.07999999999999999
+      }
+    },
+    "long": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.73099609375,
+        "action_accuracy": [
+          0.56,
+          0.44,
+          0.64,
+          0.62
+        ],
+        "first_action_accuracy": 0.56,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.5650000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.6998046875,
+        "action_accuracy": [
+          0.54,
+          0.5,
+          0.58,
+          0.5
+        ],
+        "first_action_accuracy": 0.54,
+        "four_action_exact_match": 0.12,
+        "mean_action_accuracy": 0.53
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.031191406249999942,
+        "action_accuracy": [
+          -0.020000000000000018,
+          0.06,
+          -0.06000000000000005,
+          -0.12
+        ],
+        "mean_action_accuracy": -0.03500000000000003,
+        "first_action_accuracy": -0.020000000000000018,
+        "four_action_exact_match": -0.020000000000000018
+      }
+    },
+    "medium": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.6939632415771484,
+        "action_accuracy": [
+          0.58,
+          0.6,
+          0.7,
+          0.62
+        ],
+        "first_action_accuracy": 0.58,
+        "four_action_exact_match": 0.14,
+        "mean_action_accuracy": 0.625
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.7358984375,
+        "action_accuracy": [
+          0.5,
+          0.48,
+          0.56,
+          0.54
+        ],
+        "first_action_accuracy": 0.5,
+        "four_action_exact_match": 0.08,
+        "mean_action_accuracy": 0.52
+      },
+      "candidate_minus_baseline": {
+        "loss": 0.041935195922851554,
+        "action_accuracy": [
+          -0.07999999999999996,
+          -0.12,
+          -0.1399999999999999,
+          -0.07999999999999996
+        ],
+        "mean_action_accuracy": -0.10499999999999998,
+        "first_action_accuracy": -0.07999999999999996,
+        "four_action_exact_match": -0.06000000000000001
+      }
+    },
+    "short": {
+      "baseline": {
+        "samples": 50,
+        "loss": 0.7865625,
+        "action_accuracy": [
+          0.54,
+          0.66,
+          0.64,
+          0.56
+        ],
+        "first_action_accuracy": 0.54,
+        "four_action_exact_match": 0.18,
+        "mean_action_accuracy": 0.6000000000000001
+      },
+      "candidate": {
+        "samples": 50,
+        "loss": 0.70353515625,
+        "action_accuracy": [
+          0.42,
+          0.62,
+          0.58,
+          0.64
+        ],
+        "first_action_accuracy": 0.42,
+        "four_action_exact_match": 0.0,
+        "mean_action_accuracy": 0.5650000000000001
+      },
+      "candidate_minus_baseline": {
+        "loss": -0.0830273437500001,
+        "action_accuracy": [
+          -0.12000000000000005,
+          -0.040000000000000036,
+          -0.06000000000000005,
+          0.07999999999999996
+        ],
+        "mean_action_accuracy": -0.03500000000000003,
+        "first_action_accuracy": -0.12000000000000005,
+        "four_action_exact_match": -0.18
+      }
+    }
+  }
+}

--- a/run_offline_eval.sh
+++ b/run_offline_eval.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+TEST_CASE="${1:-test_cases/vln_1}"
+OUTPUT_DIR="${2:-outputs/$(basename "$TEST_CASE")}"
+
+mkdir -p "$OUTPUT_DIR"
+exec .venv/bin/python offline_eval_uninavid.py "$TEST_CASE" "$OUTPUT_DIR"

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+exec .venv/bin/python tools/uninavid_server.py "$@"

--- a/scripts/task4_overfit_200_goal.sh
+++ b/scripts/task4_overfit_200_goal.sh
@@ -7,6 +7,12 @@ manifest="${MANIFEST:-${data_root}/task4_overfit_200_goal.json}"
 model_path="${MODEL_PATH:-${repo_root}/model_zoo/uninavid-7b-full-224-video-fps-1-grid-2}"
 output_dir="${OUTPUT_DIR:-${repo_root}/outputs/task4-overfit-200-goal}"
 max_steps="${MAX_STEPS:-400}"
+history_num_layers="${HISTORY_NUM_LAYERS:-2}"
+history_dropout="${HISTORY_DROPOUT:-0.1}"
+video_augmentation="${VIDEO_AUGMENTATION:-True}"
+learning_rate="${LEARNING_RATE:-1e-4}"
+warmup_ratio="${WARMUP_RATIO:-0.03}"
+lr_scheduler_type="${LR_SCHEDULER_TYPE:-cosine}"
 
 cd "${repo_root}"
 
@@ -18,16 +24,16 @@ cd "${repo_root}"
   --video_folder "${data_root}" \
   --vision_tower "${repo_root}/model_zoo/eva_vit_g.pth" \
   --image_processor "${repo_root}/uninavid/processor/clip-patch14-224" \
-  --video_augmentation True \
+  --video_augmentation "${video_augmentation}" \
   --tune_vision_encoder False \
   --tune_mm_mlp_adapter False \
   --history_compressor_type cross_attention \
   --history_num_queries 64 \
   --history_hidden_size 512 \
   --history_num_heads 8 \
-  --history_num_layers 2 \
+  --history_num_layers "${history_num_layers}" \
   --history_ffn_dim 2048 \
-  --history_dropout 0.1 \
+  --history_dropout "${history_dropout}" \
   --history_max_frames 512 \
   --history_goal_conditioned True \
   --tune_history_compressor True \
@@ -44,10 +50,10 @@ cd "${repo_root}"
   --max_steps "${max_steps}" \
   --per_device_train_batch_size 1 \
   --gradient_accumulation_steps 1 \
-  --learning_rate 1e-4 \
+  --learning_rate "${learning_rate}" \
   --weight_decay 0 \
-  --warmup_ratio 0.03 \
-  --lr_scheduler_type cosine \
+  --warmup_ratio "${warmup_ratio}" \
+  --lr_scheduler_type "${lr_scheduler_type}" \
   --logging_steps 10 \
   --save_strategy no \
   --evaluation_strategy no \

--- a/scripts/task4_overfit_200_goal.sh
+++ b/scripts/task4_overfit_200_goal.sh
@@ -14,6 +14,12 @@ learning_rate="${LEARNING_RATE:-1e-4}"
 warmup_ratio="${WARMUP_RATIO:-0.03}"
 lr_scheduler_type="${LR_SCHEDULER_TYPE:-cosine}"
 tune_mm_mlp_adapter="${TUNE_MM_MLP_ADAPTER:-False}"
+lr_multi="${LR_MULTI:-}"
+
+extra_train_args=()
+if [[ -n "${lr_multi}" ]]; then
+  extra_train_args+=(--lr_multi "${lr_multi}")
+fi
 
 cd "${repo_root}"
 
@@ -63,4 +69,5 @@ cd "${repo_root}"
   --dataloader_num_workers 2 \
   --lazy_preprocess True \
   --report_to none \
-  --seed 42
+  --seed 42 \
+  "${extra_train_args[@]}"

--- a/scripts/task4_overfit_200_goal.sh
+++ b/scripts/task4_overfit_200_goal.sh
@@ -13,6 +13,7 @@ video_augmentation="${VIDEO_AUGMENTATION:-True}"
 learning_rate="${LEARNING_RATE:-1e-4}"
 warmup_ratio="${WARMUP_RATIO:-0.03}"
 lr_scheduler_type="${LR_SCHEDULER_TYPE:-cosine}"
+tune_mm_mlp_adapter="${TUNE_MM_MLP_ADAPTER:-False}"
 
 cd "${repo_root}"
 
@@ -26,7 +27,7 @@ cd "${repo_root}"
   --image_processor "${repo_root}/uninavid/processor/clip-patch14-224" \
   --video_augmentation "${video_augmentation}" \
   --tune_vision_encoder False \
-  --tune_mm_mlp_adapter False \
+  --tune_mm_mlp_adapter "${tune_mm_mlp_adapter}" \
   --history_compressor_type cross_attention \
   --history_num_queries 64 \
   --history_hidden_size 512 \

--- a/scripts/task4_overfit_200_goal.sh
+++ b/scripts/task4_overfit_200_goal.sh
@@ -3,24 +3,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 data_root="${DATA_ROOT:-/home/novel/uninavid-data/task4_uninavid_full}"
-manifest="${MANIFEST:-${data_root}/task4_smoke_4_goal.json}"
+manifest="${MANIFEST:-${data_root}/task4_overfit_200_goal.json}"
 model_path="${MODEL_PATH:-${repo_root}/model_zoo/uninavid-7b-full-224-video-fps-1-grid-2}"
-output_dir="${OUTPUT_DIR:-${repo_root}/outputs/task4-smoke-cross-attention}"
+output_dir="${OUTPUT_DIR:-${repo_root}/outputs/task4-overfit-200-goal}"
+max_steps="${MAX_STEPS:-400}"
 
 cd "${repo_root}"
-
-"${repo_root}/.venv/bin/python" tools/build_task4_subset.py \
-  --samples-json "${data_root}/samples_train.json" \
-  --stock-json "${data_root}/uninavid_train_goal.json" \
-  --output "${manifest}" \
-  --per-bin 1 \
-  --seed 42
-
-"${repo_root}/.venv/bin/python" tools/smoke_task4_loader.py \
-  --manifest "${manifest}" \
-  --video-folder "${data_root}" \
-  --model-path "${model_path}" \
-  --image-processor "${repo_root}/uninavid/processor/clip-patch14-224"
 
 "${repo_root}/.venv/bin/python" -m uninavid.train.train \
   --model_name_or_path "${model_path}" \
@@ -30,6 +18,7 @@ cd "${repo_root}"
   --video_folder "${data_root}" \
   --vision_tower "${repo_root}/model_zoo/eva_vit_g.pth" \
   --image_processor "${repo_root}/uninavid/processor/clip-patch14-224" \
+  --video_augmentation True \
   --tune_vision_encoder False \
   --tune_mm_mlp_adapter False \
   --history_compressor_type cross_attention \
@@ -52,17 +41,19 @@ cd "${repo_root}"
   --bf16 True \
   --tf32 True \
   --output_dir "${output_dir}" \
-  --max_steps 1 \
+  --max_steps "${max_steps}" \
   --per_device_train_batch_size 1 \
   --gradient_accumulation_steps 1 \
   --learning_rate 1e-4 \
   --weight_decay 0 \
-  --warmup_ratio 0 \
-  --logging_steps 1 \
+  --warmup_ratio 0.03 \
+  --lr_scheduler_type cosine \
+  --logging_steps 10 \
   --save_strategy no \
   --evaluation_strategy no \
   --model_max_length 2048 \
   --gradient_checkpointing False \
-  --dataloader_num_workers 0 \
+  --dataloader_num_workers 2 \
   --lazy_preprocess True \
-  --report_to none
+  --report_to none \
+  --seed 42

--- a/scripts/task4_smoke_train.sh
+++ b/scripts/task4_smoke_train.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+data_root="${DATA_ROOT:-/home/novel/uninavid-data/task4_uninavid_full}"
+manifest="${MANIFEST:-${data_root}/task4_smoke_4.json}"
+model_path="${MODEL_PATH:-${repo_root}/model_zoo/uninavid-7b-full-224-video-fps-1-grid-2}"
+output_dir="${OUTPUT_DIR:-${repo_root}/outputs/task4-smoke-baseline}"
+
+cd "${repo_root}"
+
+"${repo_root}/.venv/bin/python" tools/build_task4_subset.py \
+  --samples-json "${data_root}/samples_train.json" \
+  --stock-json "${data_root}/uninavid_train.json" \
+  --output "${manifest}" \
+  --per-bin 1 \
+  --seed 42
+
+"${repo_root}/.venv/bin/python" tools/smoke_task4_loader.py \
+  --manifest "${manifest}" \
+  --video-folder "${data_root}" \
+  --model-path "${model_path}" \
+  --image-processor "${repo_root}/uninavid/processor/clip-patch14-224"
+
+"${repo_root}/.venv/bin/python" -m uninavid.train.train \
+  --model_name_or_path "${model_path}" \
+  --version imgsp_v1 \
+  --data_path "${manifest}" \
+  --image_folder "${data_root}" \
+  --video_folder "${data_root}" \
+  --vision_tower "${repo_root}/model_zoo/eva_vit_g.pth" \
+  --image_processor "${repo_root}/uninavid/processor/clip-patch14-224" \
+  --tune_vision_encoder False \
+  --tune_mm_mlp_adapter True \
+  --mm_projector_type mlp2x_gelu \
+  --mm_vision_select_layer -2 \
+  --mm_use_im_start_end False \
+  --mm_use_im_patch_token False \
+  --image_aspect_ratio pad \
+  --video_fps 1 \
+  --compress_type grid:2 \
+  --bf16 True \
+  --tf32 True \
+  --output_dir "${output_dir}" \
+  --max_steps 1 \
+  --per_device_train_batch_size 1 \
+  --gradient_accumulation_steps 1 \
+  --learning_rate 1e-5 \
+  --weight_decay 0 \
+  --warmup_ratio 0 \
+  --logging_steps 1 \
+  --save_strategy no \
+  --evaluation_strategy no \
+  --model_max_length 2048 \
+  --gradient_checkpointing False \
+  --dataloader_num_workers 0 \
+  --lazy_preprocess True \
+  --report_to none

--- a/scripts/task4_smoke_train_learned.sh
+++ b/scripts/task4_smoke_train_learned.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+data_root="${DATA_ROOT:-/home/novel/uninavid-data/task4_uninavid_full}"
+manifest="${MANIFEST:-${data_root}/task4_smoke_4.json}"
+model_path="${MODEL_PATH:-${repo_root}/model_zoo/uninavid-7b-full-224-video-fps-1-grid-2}"
+output_dir="${OUTPUT_DIR:-${repo_root}/outputs/task4-smoke-cross-attention}"
+
+cd "${repo_root}"
+
+"${repo_root}/.venv/bin/python" tools/build_task4_subset.py \
+  --samples-json "${data_root}/samples_train.json" \
+  --stock-json "${data_root}/uninavid_train.json" \
+  --output "${manifest}" \
+  --per-bin 1 \
+  --seed 42
+
+"${repo_root}/.venv/bin/python" tools/smoke_task4_loader.py \
+  --manifest "${manifest}" \
+  --video-folder "${data_root}" \
+  --model-path "${model_path}" \
+  --image-processor "${repo_root}/uninavid/processor/clip-patch14-224"
+
+"${repo_root}/.venv/bin/python" -m uninavid.train.train \
+  --model_name_or_path "${model_path}" \
+  --version imgsp_v1 \
+  --data_path "${manifest}" \
+  --image_folder "${data_root}" \
+  --video_folder "${data_root}" \
+  --vision_tower "${repo_root}/model_zoo/eva_vit_g.pth" \
+  --image_processor "${repo_root}/uninavid/processor/clip-patch14-224" \
+  --tune_vision_encoder False \
+  --tune_mm_mlp_adapter False \
+  --history_compressor_type cross_attention \
+  --history_num_queries 64 \
+  --history_hidden_size 512 \
+  --history_num_heads 8 \
+  --history_num_layers 2 \
+  --history_ffn_dim 2048 \
+  --history_dropout 0.1 \
+  --history_max_frames 512 \
+  --tune_history_compressor True \
+  --mm_projector_type mlp2x_gelu \
+  --mm_vision_select_layer -2 \
+  --mm_use_im_start_end False \
+  --mm_use_im_patch_token False \
+  --image_aspect_ratio pad \
+  --compress_type grid:2 \
+  --video_fps 1 \
+  --bf16 True \
+  --tf32 True \
+  --output_dir "${output_dir}" \
+  --max_steps 1 \
+  --per_device_train_batch_size 1 \
+  --gradient_accumulation_steps 1 \
+  --learning_rate 1e-4 \
+  --weight_decay 0 \
+  --warmup_ratio 0 \
+  --logging_steps 1 \
+  --save_strategy no \
+  --evaluation_strategy no \
+  --model_max_length 2048 \
+  --gradient_checkpointing False \
+  --dataloader_num_workers 0 \
+  --lazy_preprocess True \
+  --report_to none

--- a/tests/test_history_compressor.py
+++ b/tests/test_history_compressor.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+import unittest
+
+import torch
+import torch.nn as nn
+
+from uninavid.constants import NAVIGATION_IDENTIFIER
+from uninavid.model.history_compressor import LearnedHistoryCompressor
+from uninavid.model.uninavid_arch import UniNaVIDMetaForCausalLM
+
+
+class HistoryCompressorTest(unittest.TestCase):
+    def build_compressor(self):
+        return LearnedHistoryCompressor(
+            vision_dim=32,
+            hidden_dim=16,
+            num_queries=8,
+            num_heads=4,
+            num_layers=2,
+            ffn_dim=32,
+            dropout=0.0,
+        )
+
+    def test_output_shape_for_variable_and_empty_history(self):
+        compressor = self.build_compressor()
+        for frame_count in (0, 1, 65):
+            history = torch.randn(2, frame_count, 64, 32)
+            output = compressor(history)
+            self.assertEqual(output.shape, (2, 8, 32))
+
+    def test_gradients_reach_compressor(self):
+        compressor = self.build_compressor()
+        output = compressor(torch.randn(1, 3, 64, 32))
+        output.square().mean().backward()
+
+        self.assertIsNotNone(compressor.query_tokens.grad)
+        self.assertIsNotNone(compressor.input_projection.weight.grad)
+        self.assertIsNotNone(compressor.output_projection.weight.grad)
+        self.assertIsNotNone(compressor.spatial_embedding.grad)
+        self.assertIsNotNone(compressor.temporal_embedding.weight.grad)
+
+    def test_output_changes_when_frame_order_changes(self):
+        compressor = self.build_compressor().eval()
+        history = torch.randn(1, 4, 64, 32)
+
+        original = compressor(history)
+        reversed_history = compressor(history.flip(1))
+
+        self.assertFalse(torch.allclose(original, reversed_history, atol=1e-6))
+
+    def test_output_changes_when_spatial_positions_change(self):
+        compressor = self.build_compressor().eval()
+        history = torch.randn(1, 1, 64, 32)
+
+        original = compressor(history)
+        spatially_reversed = compressor(history.flip(2))
+
+        self.assertFalse(torch.allclose(original, spatially_reversed, atol=1e-6))
+
+    def test_rejects_non_8x8_frame_tokens(self):
+        compressor = self.build_compressor()
+        with self.assertRaisesRegex(ValueError, "expected 64 tokens per frame"):
+            compressor(torch.randn(1, 2, 16, 32))
+
+
+class DummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mm_projector = nn.Linear(32, 48)
+        self.history_compressor = LearnedHistoryCompressor(
+            vision_dim=32,
+            hidden_dim=16,
+            num_queries=8,
+            num_heads=4,
+            num_layers=1,
+            ffn_dim=32,
+            dropout=0.0,
+        )
+
+
+class ArchitectureHarness(UniNaVIDMetaForCausalLM):
+    def __init__(self):
+        self.model = DummyModel()
+        self.config = SimpleNamespace(
+            compress_type="grid:2",
+            history_compressor_type="cross_attention",
+            mm_vision_select_feature="patch",
+            run_type="train",
+        )
+
+    def get_model(self):
+        return self.model
+
+
+class HistoryCompressorIntegrationTest(unittest.TestCase):
+    def test_navigation_path_keeps_current_frame_separate(self):
+        harness = ArchitectureHarness()
+        prompt = [[f"{NAVIGATION_IDENTIFIER}. Search for a chair."]]
+        features = torch.randn(3, 256, 32)
+
+        history, video_flags, current, token_lengths = harness.vlm_attention(
+            features,
+            prompts=prompt,
+            image_counts=[3],
+        )
+
+        self.assertEqual(history[0].shape, (1, 8, 48))
+        self.assertEqual(current[0].shape, (1, 64, 48))
+        self.assertEqual(token_lengths, [[8]])
+        self.assertEqual(video_flags, [True])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_history_compressor.py
+++ b/tests/test_history_compressor.py
@@ -62,6 +62,43 @@ class HistoryCompressorTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "expected 64 tokens per frame"):
             compressor(torch.randn(1, 2, 16, 32))
 
+    def test_goal_conditioning_changes_output_and_receives_gradients(self):
+        compressor = LearnedHistoryCompressor(
+            vision_dim=32,
+            hidden_dim=16,
+            num_queries=8,
+            num_heads=4,
+            num_layers=1,
+            ffn_dim=32,
+            dropout=0.0,
+            goal_dim=24,
+        ).eval()
+        history = torch.randn(1, 3, 64, 32)
+        goal_mask = torch.ones(1, 4, dtype=torch.long)
+        chair_goal = torch.randn(1, 4, 24)
+        toilet_goal = torch.randn(1, 4, 24)
+
+        chair_output = compressor(history, chair_goal, goal_mask)
+        toilet_output = compressor(history, toilet_goal, goal_mask)
+
+        self.assertFalse(torch.allclose(chair_output, toilet_output, atol=1e-6))
+        chair_output.square().mean().backward()
+        self.assertIsNotNone(compressor.goal_projection[1].weight.grad)
+
+    def test_goal_conditioning_rejects_missing_goal(self):
+        compressor = LearnedHistoryCompressor(
+            vision_dim=32,
+            hidden_dim=16,
+            num_queries=8,
+            num_heads=4,
+            num_layers=1,
+            ffn_dim=32,
+            dropout=0.0,
+            goal_dim=24,
+        )
+        with self.assertRaisesRegex(ValueError, "requires goal features"):
+            compressor(torch.randn(1, 2, 64, 32))
+
 
 class DummyModel(nn.Module):
     def __init__(self):

--- a/tools/build_task4_subset.py
+++ b/tools/build_task4_subset.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Build a history-length-balanced stock-loader manifest for Task 4."""
+
+import argparse
+import json
+import random
+from collections import defaultdict
+from pathlib import Path
+
+
+BINS = (
+    ("short", 0, 64),
+    ("medium", 64, 128),
+    ("long", 128, 256),
+    ("extra_long", 256, None),
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--samples-json", type=Path, required=True)
+    parser.add_argument("--stock-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--per-bin", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def bin_name(time_index):
+    for name, lower, upper in BINS:
+        if time_index >= lower and (upper is None or time_index < upper):
+            return name
+    raise ValueError(f"Invalid time_index: {time_index}")
+
+
+def main():
+    args = parse_args()
+    if args.per_bin < 1:
+        raise ValueError("--per-bin must be positive")
+
+    samples = json.loads(args.samples_json.read_text())
+    stock = json.loads(args.stock_json.read_text())
+    stock_by_id = {item["id"]: item for item in stock}
+    if len(stock_by_id) != len(stock):
+        raise ValueError("Stock manifest contains duplicate IDs")
+
+    grouped = defaultdict(list)
+    for sample in samples:
+        grouped[bin_name(sample["time_index"])].append(sample)
+
+    rng = random.Random(args.seed)
+    selected = []
+    summary = {}
+    for name, _, _ in BINS:
+        candidates = grouped[name]
+        if len(candidates) < args.per_bin:
+            raise ValueError(
+                f"Bin {name} has {len(candidates)} samples, fewer than {args.per_bin}"
+            )
+        chosen = rng.sample(candidates, args.per_bin)
+        missing = [sample["id"] for sample in chosen if sample["id"] not in stock_by_id]
+        if missing:
+            raise ValueError(f"IDs missing from stock manifest: {missing[:5]}")
+        selected.extend(stock_by_id[sample["id"]] for sample in chosen)
+        summary[name] = {
+            "samples": len(chosen),
+            "trajectories": len({sample["episode"] for sample in chosen}),
+            "scenes": len({sample["scene_id"] for sample in chosen}),
+        }
+
+    rng.shuffle(selected)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(selected, indent=2) + "\n")
+    print(json.dumps({"output": str(args.output), "total": len(selected), **summary}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_task4_results.py
+++ b/tools/compare_task4_results.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Compare two Task 4 evaluation JSON files."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def summarize(metrics):
+    accuracies = metrics["action_accuracy"]
+    return {
+        **metrics,
+        "mean_action_accuracy": sum(accuracies) / len(accuracies),
+    }
+
+
+def delta(candidate, baseline):
+    return {
+        "loss": candidate["loss"] - baseline["loss"],
+        "action_accuracy": [
+            candidate_value - baseline_value
+            for candidate_value, baseline_value in zip(
+                candidate["action_accuracy"],
+                baseline["action_accuracy"],
+            )
+        ],
+        "mean_action_accuracy": (
+            candidate["mean_action_accuracy"]
+            - baseline["mean_action_accuracy"]
+        ),
+        "first_action_accuracy": (
+            candidate["first_action_accuracy"]
+            - baseline["first_action_accuracy"]
+        ),
+        "four_action_exact_match": (
+            candidate["four_action_exact_match"]
+            - baseline["four_action_exact_match"]
+        ),
+    }
+
+
+def main():
+    args = parse_args()
+    baseline_raw = json.loads(args.baseline.read_text())
+    candidate_raw = json.loads(args.candidate.read_text())
+    if baseline_raw["manifest"] != candidate_raw["manifest"]:
+        raise ValueError("Evaluation manifests do not match")
+    if baseline_raw["teacher_forced"] != candidate_raw["teacher_forced"]:
+        raise ValueError("Evaluation protocols do not match")
+
+    baseline = summarize(baseline_raw["overall"])
+    candidate = summarize(candidate_raw["overall"])
+    result = {
+        "manifest": baseline_raw["manifest"],
+        "teacher_forced": baseline_raw["teacher_forced"],
+        "baseline_mode": baseline_raw["mode"],
+        "candidate_mode": candidate_raw["mode"],
+        "baseline": baseline,
+        "candidate": candidate,
+        "candidate_minus_baseline": delta(candidate, baseline),
+        "by_history_bin": {},
+    }
+    for name in sorted(baseline_raw["by_history_bin"]):
+        baseline_bin = summarize(baseline_raw["by_history_bin"][name])
+        candidate_bin = summarize(candidate_raw["by_history_bin"][name])
+        result["by_history_bin"][name] = {
+            "baseline": baseline_bin,
+            "candidate": candidate_bin,
+            "candidate_minus_baseline": delta(candidate_bin, baseline_bin),
+        }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/download_mp.py
+++ b/tools/download_mp.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Download Matterport3D release files with Python 3.
+
+This is a Python 3 compatible version of the Matterport3D public data release
+script. Only download the file types you need; the complete release is large.
+"""
+
+import argparse
+import os
+import tempfile
+import urllib.request
+
+BASE_URL = "http://kaldir.vc.cit.tum.de/matterport/"
+RELEASE = "v1/scans"
+RELEASE_TASKS = "v1/tasks"
+RELEASE_SIZE = "1.3TB"
+TOS_URL = BASE_URL + "MP_TOS.pdf"
+
+FILETYPES = [
+    "cameras",
+    "matterport_camera_intrinsics",
+    "matterport_camera_poses",
+    "matterport_color_images",
+    "matterport_depth_images",
+    "matterport_hdr_images",
+    "matterport_mesh",
+    "matterport_skybox_images",
+    "undistorted_camera_parameters",
+    "undistorted_color_images",
+    "undistorted_depth_images",
+    "undistorted_normal_images",
+    "house_segmentations",
+    "region_segmentations",
+    "image_overlap_data",
+    "poisson_meshes",
+    "sens",
+]
+
+TASK_FILES = {
+    "keypoint_matching_data": ["keypoint_matching/data.zip"],
+    "keypoint_matching_models": ["keypoint_matching/models.zip"],
+    "surface_normal_data": ["surface_normal/data_list.zip"],
+    "surface_normal_models": ["surface_normal/models.zip"],
+    "region_classification_data": ["region_classification/data.zip"],
+    "region_classification_models": ["region_classification/models.zip"],
+    "semantic_voxel_label_data": ["semantic_voxel_label/data.zip"],
+    "semantic_voxel_label_models": ["semantic_voxel_label/models.zip"],
+    "minos": ["mp3d_minos.zip"],
+    "gibson": ["mp3d_for_gibson.tar.gz"],
+    "habitat": ["mp3d_habitat.zip"],
+    "pixelsynth": ["mp3d_pixelsynth.zip"],
+    "igibson": ["mp3d_for_igibson.zip"],
+    "mp360": [
+        "mp3d_360/data_00.zip",
+        "mp3d_360/data_01.zip",
+        "mp3d_360/data_02.zip",
+        "mp3d_360/data_03.zip",
+        "mp3d_360/data_04.zip",
+        "mp3d_360/data_05.zip",
+        "mp3d_360/data_06.zip",
+    ],
+}
+
+
+def get_release_scans(release_file):
+    with urllib.request.urlopen(release_file) as response:
+        return [line.decode("utf-8").strip() for line in response if line.strip()]
+
+
+def download_file(url, out_file):
+    out_dir = os.path.dirname(out_file)
+    os.makedirs(out_dir, exist_ok=True)
+    if os.path.isfile(out_file):
+        print(f"WARNING: skipping existing file {out_file}")
+        return
+
+    print(f"\t{url} > {out_file}")
+    fd, tmp_file = tempfile.mkstemp(dir=out_dir)
+    os.close(fd)
+    try:
+        urllib.request.urlretrieve(url, tmp_file)
+        os.rename(tmp_file, out_file)
+    finally:
+        if os.path.exists(tmp_file):
+            os.remove(tmp_file)
+
+
+def download_scan(scan_id, out_dir, file_types):
+    print(f"Downloading MP scan {scan_id} ...")
+    os.makedirs(out_dir, exist_ok=True)
+    for file_type in file_types:
+        url = f"{BASE_URL}{RELEASE}/{scan_id}/{file_type}.zip"
+        download_file(url, os.path.join(out_dir, f"{file_type}.zip"))
+    print(f"Downloaded scan {scan_id}")
+
+
+def download_release(scan_ids, out_dir, file_types):
+    print(f"Downloading MP release to {out_dir} ...")
+    for scan_id in scan_ids:
+        download_scan(scan_id, os.path.join(out_dir, scan_id), file_types)
+    print("Downloaded MP release.")
+
+
+def download_task_data(task_data, out_dir):
+    print(f"Downloading MP task data for {task_data} ...")
+    for task_data_id in task_data:
+        for file_part in TASK_FILES[task_data_id]:
+            url = f"{BASE_URL}{RELEASE_TASKS}/{file_part}"
+            download_file(url, os.path.join(out_dir, file_part))
+    print(f"Done downloading task data for {task_data}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download Matterport3D public data release.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("-o", "--out_dir", required=True, help="download directory")
+    parser.add_argument("--id", default="ALL", help="scan id, or ALL")
+    parser.add_argument("--type", nargs="+", default=None, help="file types to download")
+    parser.add_argument("--task_data", nargs="+", default=[], help="task data ids to download")
+    parser.add_argument("--yes", action="store_true", help="skip interactive TOS prompts")
+    args = parser.parse_args()
+
+    file_types = args.type or FILETYPES
+    invalid_types = sorted(set(file_types) - set(FILETYPES))
+    invalid_tasks = sorted(set(args.task_data) - set(TASK_FILES))
+    if invalid_types:
+        raise SystemExit(f"Invalid file type(s): {', '.join(invalid_types)}")
+    if invalid_tasks:
+        raise SystemExit(f"Invalid task data id(s): {', '.join(invalid_tasks)}")
+
+    print("Continuing confirms that you have agreed to the MP terms of use:")
+    print(TOS_URL)
+    if not args.yes:
+        input("Press Enter to continue, or CTRL-C to exit.")
+
+    if args.task_data:
+        download_task_data(args.task_data, os.path.join(args.out_dir, RELEASE_TASKS))
+
+    release_scans = get_release_scans(BASE_URL + RELEASE + ".txt")
+    scan_id = args.id
+    if scan_id and scan_id.lower() != "all":
+        if scan_id not in release_scans:
+            raise SystemExit(f"Invalid scan id: {scan_id}")
+        download_scan(scan_id, os.path.join(args.out_dir, RELEASE, scan_id), file_types)
+        return
+
+    if len(file_types) == len(FILETYPES):
+        print(f"WARNING: the entire MP release requires about {RELEASE_SIZE}.")
+    else:
+        print(f"WARNING: downloading all MP scans for: {', '.join(file_types)}")
+    if not args.yes:
+        input("Press Enter to continue, or CTRL-C to exit.")
+    download_release(release_scans, os.path.join(args.out_dir, RELEASE), file_types)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/enrich_task4_manifest.py
+++ b/tools/enrich_task4_manifest.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Add explicit goal metadata to a stock Uni-NaVid Task 4 manifest."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--samples-json", type=Path, required=True)
+    parser.add_argument("--stock-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    samples = json.loads(args.samples_json.read_text())
+    stock = json.loads(args.stock_json.read_text())
+    metadata_by_id = {sample["id"]: sample for sample in samples}
+
+    if len(metadata_by_id) != len(samples):
+        raise ValueError("Sample metadata contains duplicate IDs")
+
+    enriched = []
+    for item in stock:
+        metadata = metadata_by_id.get(item["id"])
+        if metadata is None:
+            raise ValueError(f"Missing metadata for {item['id']}")
+        enriched.append({
+            **item,
+            "goal": metadata["goal"],
+            "instruction": metadata["instruction"],
+            "episode": metadata["episode"],
+            "time_index": metadata["time_index"],
+            "history_frame_count": metadata["history_frame_count"],
+            "scene_id": metadata["scene_id"],
+        })
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(enriched, indent=2) + "\n")
+    print(json.dumps({
+        "output": str(args.output),
+        "samples": len(enriched),
+        "goals": sorted({item["goal"] for item in enriched}),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/evaluate_task4.py
+++ b/tools/evaluate_task4.py
@@ -48,17 +48,26 @@ def history_bin(time_index):
     return "extra_long"
 
 
-def load_history_adapter(model, path):
+def load_multimodal_adapter(model, path):
     state = torch.load(path, map_location="cpu", weights_only=True)
-    prefix = "model.history_compressor."
+    compressor_prefix = "model.history_compressor."
     compressor_state = {
-        key[len(prefix):]: value
+        key[len(compressor_prefix):]: value
         for key, value in state.items()
-        if key.startswith(prefix)
+        if key.startswith(compressor_prefix)
     }
     if not compressor_state:
         raise ValueError(f"No history compressor weights found in {path}")
     model.get_model().history_compressor.load_state_dict(compressor_state)
+
+    projector_prefix = "model.mm_projector."
+    projector_state = {
+        key[len(projector_prefix):]: value
+        for key, value in state.items()
+        if key.startswith(projector_prefix)
+    }
+    if projector_state:
+        model.get_model().mm_projector.load_state_dict(projector_state)
 
 
 def build_model(args, device):
@@ -93,7 +102,7 @@ def build_model(args, device):
     if args.adapter is not None:
         if not learned:
             raise ValueError("--adapter is only valid for learned compressor modes")
-        load_history_adapter(model, args.adapter)
+        load_multimodal_adapter(model, args.adapter)
     elif learned:
         raise ValueError("Learned compressor modes require --adapter")
 

--- a/tools/evaluate_task4.py
+++ b/tools/evaluate_task4.py
@@ -31,6 +31,8 @@ def parse_args():
         required=True,
     )
     parser.add_argument("--adapter", type=Path)
+    parser.add_argument("--history-num-layers", type=int, default=2)
+    parser.add_argument("--history-dropout", type=float, default=0.1)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--max-samples", type=int)
     return parser.parse_args()
@@ -81,9 +83,9 @@ def build_model(args, device):
         history_num_queries=64,
         history_hidden_size=512,
         history_num_heads=8,
-        history_num_layers=2,
+        history_num_layers=args.history_num_layers,
         history_ffn_dim=2048,
-        history_dropout=0.1,
+        history_dropout=args.history_dropout,
         history_max_frames=512,
         history_goal_conditioned=goal_conditioned,
     )

--- a/tools/evaluate_task4.py
+++ b/tools/evaluate_task4.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Teacher-forced offline evaluation for Task 4 navigation manifests."""
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from transformers import AutoConfig, AutoTokenizer, CLIPImageProcessor
+
+from uninavid.model import LlavaLlamaAttForCausalLM
+from uninavid.train.train import (
+    DataArguments,
+    DataCollatorForSupervisedDataset,
+    LazySupervisedDataset,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--video-folder", type=Path, required=True)
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("--vision-tower", type=Path, required=True)
+    parser.add_argument("--image-processor", type=Path, required=True)
+    parser.add_argument(
+        "--mode",
+        choices=("heuristic", "cross_attention", "goal_cross_attention"),
+        required=True,
+    )
+    parser.add_argument("--adapter", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--max-samples", type=int)
+    return parser.parse_args()
+
+
+def history_bin(time_index):
+    if time_index < 64:
+        return "short"
+    if time_index < 128:
+        return "medium"
+    if time_index < 256:
+        return "long"
+    return "extra_long"
+
+
+def load_history_adapter(model, path):
+    state = torch.load(path, map_location="cpu", weights_only=True)
+    prefix = "model.history_compressor."
+    compressor_state = {
+        key[len(prefix):]: value
+        for key, value in state.items()
+        if key.startswith(prefix)
+    }
+    if not compressor_state:
+        raise ValueError(f"No history compressor weights found in {path}")
+    model.get_model().history_compressor.load_state_dict(compressor_state)
+
+
+def build_model(args, device):
+    learned = args.mode != "heuristic"
+    goal_conditioned = args.mode == "goal_cross_attention"
+    config = AutoConfig.from_pretrained(args.model_path, trust_remote_code=True)
+    model = LlavaLlamaAttForCausalLM.from_pretrained(
+        args.model_path,
+        config=config,
+        torch_dtype=torch.bfloat16,
+    )
+    model_args = SimpleNamespace(
+        vision_tower=str(args.vision_tower),
+        image_processor=str(args.image_processor),
+        mm_vision_select_layer=-2,
+        mm_vision_select_feature="patch",
+        pretrain_mm_mlp_adapter=None,
+        mm_projector_type="mlp2x_gelu",
+        compress_type="grid:2",
+        run_type="train",
+        history_compressor_type="cross_attention" if learned else "heuristic",
+        history_num_queries=64,
+        history_hidden_size=512,
+        history_num_heads=8,
+        history_num_layers=2,
+        history_ffn_dim=2048,
+        history_dropout=0.1,
+        history_max_frames=512,
+        history_goal_conditioned=goal_conditioned,
+    )
+    model.get_model().initialize_vision_modules(model_args=model_args, max_token=2048)
+    if args.adapter is not None:
+        if not learned:
+            raise ValueError("--adapter is only valid for learned compressor modes")
+        load_history_adapter(model, args.adapter)
+    elif learned:
+        raise ValueError("Learned compressor modes require --adapter")
+
+    model.config.mm_use_im_start_end = False
+    model.config.mm_use_im_patch_token = False
+    model.config.image_aspect_ratio = "pad"
+    model.to(device=device, dtype=torch.bfloat16)
+    if learned:
+        model.get_model().history_compressor.to(
+            device=device,
+            dtype=torch.bfloat16,
+        )
+    model.eval()
+    return model
+
+
+def make_dataset(args, tokenizer, image_processor):
+    data_args = DataArguments(
+        data_path=str(args.manifest),
+        lazy_preprocess=True,
+        is_multimodal=True,
+        video_folder=str(args.video_folder),
+        video_fps=1,
+        image_aspect_ratio="pad",
+        video_augmentation=False,
+    )
+    data_args.image_processor = image_processor
+    data_args.mm_use_im_start_end = False
+    dataset = LazySupervisedDataset(
+        data_path=str(args.manifest),
+        tokenizer=tokenizer,
+        data_args=data_args,
+    )
+    return dataset, DataCollatorForSupervisedDataset(tokenizer)
+
+
+def new_metrics():
+    return {
+        "samples": 0,
+        "loss_sum": 0.0,
+        "position_correct": [0, 0, 0, 0],
+        "exact_match": 0,
+    }
+
+
+def update_metrics(metrics, loss, predictions, labels):
+    metrics["samples"] += 1
+    metrics["loss_sum"] += loss
+    for index in range(4):
+        metrics["position_correct"][index] += int(
+            predictions[index] == labels[index]
+        )
+    metrics["exact_match"] += int(predictions[:4] == labels[:4])
+
+
+def finalize_metrics(metrics):
+    samples = metrics["samples"]
+    return {
+        "samples": samples,
+        "loss": metrics["loss_sum"] / samples,
+        "action_accuracy": [value / samples for value in metrics["position_correct"]],
+        "first_action_accuracy": metrics["position_correct"][0] / samples,
+        "four_action_exact_match": metrics["exact_match"] / samples,
+    }
+
+
+def move_to_device(value, device):
+    if isinstance(value, torch.Tensor):
+        if value.is_floating_point():
+            return value.to(device=device, dtype=torch.bfloat16)
+        return value.to(device=device)
+    if isinstance(value, list):
+        return [move_to_device(item, device) for item in value]
+    return value
+
+
+def main():
+    args = parse_args()
+    device = torch.device("cuda")
+    manifest = json.loads(args.manifest.read_text())
+    if args.max_samples is not None:
+        manifest = manifest[:args.max_samples]
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path, use_fast=False)
+    tokenizer.model_max_length = 2048
+    tokenizer.padding_side = "right"
+    tokenizer.pad_token = tokenizer.unk_token
+    image_processor = CLIPImageProcessor.from_pretrained(args.image_processor)
+    model = build_model(args, device)
+    dataset, collator = make_dataset(args, tokenizer, image_processor)
+
+    totals = new_metrics()
+    by_bin = defaultdict(new_metrics)
+    for index, metadata in enumerate(manifest):
+        batch = collator([dataset[index]])
+        batch = {key: move_to_device(value, device) for key, value in batch.items()}
+        with torch.inference_mode():
+            output = model(**batch)
+
+        shifted_labels = batch["labels"][:, 1:]
+        labels = shifted_labels[shifted_labels.ne(-100)].tolist()
+        shifted_predictions = output.logits[:, :-1].argmax(dim=-1)
+        predictions = shifted_predictions[0, -len(labels):].tolist()
+        if len(labels) < 4:
+            raise ValueError(f"Sample {metadata['id']} has fewer than four targets")
+
+        loss = float(output.loss)
+        update_metrics(totals, loss, predictions, labels)
+        update_metrics(
+            by_bin[history_bin(metadata["time_index"])],
+            loss,
+            predictions,
+            labels,
+        )
+        if (index + 1) % 10 == 0:
+            print(f"evaluated={index + 1}/{len(manifest)}")
+
+    result = {
+        "mode": args.mode,
+        "manifest": str(args.manifest),
+        "overall": finalize_metrics(totals),
+        "by_history_bin": {
+            name: finalize_metrics(metrics)
+            for name, metrics in sorted(by_bin.items())
+        },
+        "teacher_forced": True,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/smoke_task4_loader.py
+++ b/tools/smoke_task4_loader.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Exercise Uni-NaVid's stock loader against a Task 4 manifest."""
+
+import argparse
+from pathlib import Path
+
+from transformers import AutoTokenizer, CLIPImageProcessor
+
+from uninavid.train.train import (
+    DataArguments,
+    DataCollatorForSupervisedDataset,
+    LazySupervisedDataset,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--video-folder", type=Path, required=True)
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("--image-processor", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path, use_fast=False)
+    tokenizer.model_max_length = 2048
+    tokenizer.padding_side = "right"
+    tokenizer.pad_token = tokenizer.unk_token
+
+    data_args = DataArguments(
+        data_path=str(args.manifest),
+        lazy_preprocess=True,
+        is_multimodal=True,
+        video_folder=str(args.video_folder),
+        video_fps=1,
+        image_aspect_ratio="pad",
+    )
+    data_args.image_processor = CLIPImageProcessor.from_pretrained(args.image_processor)
+    data_args.mm_use_im_start_end = False
+
+    dataset = LazySupervisedDataset(
+        data_path=str(args.manifest), tokenizer=tokenizer, data_args=data_args
+    )
+    instances = [dataset[index] for index in range(len(dataset))]
+    collator = DataCollatorForSupervisedDataset(tokenizer)
+    batch = collator(instances[:1])
+
+    frame_counts = [instance["image"].shape[0] for instance in instances]
+    supervised_tokens = [int((instance["labels"] != -100).sum()) for instance in instances]
+    print(f"samples={len(instances)}")
+    print(f"frame_counts={frame_counts}")
+    print(f"supervised_tokens={supervised_tokens}")
+    print(f"batch_input_shape={tuple(batch['input_ids'].shape)}")
+    print(f"batch_video_shape={tuple(batch['images'][0].shape)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/smoke_task4_loader.py
+++ b/tools/smoke_task4_loader.py
@@ -54,6 +54,12 @@ def main():
     print(f"supervised_tokens={supervised_tokens}")
     print(f"batch_input_shape={tuple(batch['input_ids'].shape)}")
     print(f"batch_video_shape={tuple(batch['images'][0].shape)}")
+    if 'goal_input_ids' in batch:
+        print(f"batch_goal_shape={tuple(batch['goal_input_ids'].shape)}")
+        print(
+            "goal_tokens="
+            f"{batch['goal_attention_mask'].sum(dim=1).tolist()}"
+        )
 
 
 if __name__ == "__main__":

--- a/tools/uninavid_server.py
+++ b/tools/uninavid_server.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+from typing import List, Optional
+
+import cv2
+import numpy as np
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+from offline_eval_uninavid import UniNaVid_Agent
+
+
+class PredictRequest(BaseModel):
+    instruction: str
+    image_b64: str
+
+
+class PredictResponse(BaseModel):
+    actions: List[str]
+    trajectory: List[List[float]]
+    elapsed_sec: float
+    raw: dict
+
+
+app = FastAPI()
+agent: Optional[UniNaVid_Agent] = None
+
+
+def decode_image(image_b64: str):
+    payload = base64.b64decode(image_b64)
+    data = np.frombuffer(payload, dtype=np.uint8)
+    image = cv2.imdecode(data, cv2.IMREAD_COLOR)
+    if image is None:
+        raise ValueError("failed to decode image_b64")
+    return image
+
+
+@app.post("/reset")
+def reset():
+    agent.reset()
+    return {"ok": True}
+
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(req: PredictRequest):
+    image = decode_image(req.image_b64)
+    start = time.time()
+    result = agent.act({"instruction": req.instruction, "observations": image})
+    elapsed = time.time() - start
+    return {
+        "actions": result["actions"],
+        "trajectory": result["path"][0],
+        "elapsed_sec": elapsed,
+        "raw": result,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", default="model_zoo/uninavid-7b-full-224-video-fps-1-grid-2")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8088)
+    args = parser.parse_args()
+
+    os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    global agent
+    agent = UniNaVid_Agent(args.model_path)
+    agent.reset()
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/uninavid/model/history_compressor.py
+++ b/uninavid/model/history_compressor.py
@@ -1,0 +1,118 @@
+import torch
+import torch.nn as nn
+
+
+class LearnedHistoryCompressor(nn.Module):
+    """Compress variable-length 8x8 frame tokens into fixed learned queries."""
+
+    def __init__(
+        self,
+        vision_dim=1408,
+        hidden_dim=512,
+        num_queries=64,
+        num_heads=8,
+        num_layers=2,
+        ffn_dim=2048,
+        dropout=0.1,
+        tokens_per_frame=64,
+        max_history_frames=512,
+    ):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        if max_history_frames < 1:
+            raise ValueError("max_history_frames must be positive")
+
+        self.num_queries = num_queries
+        self.tokens_per_frame = tokens_per_frame
+        self.vision_dim = vision_dim
+        self.max_history_frames = max_history_frames
+
+        self.input_norm = nn.LayerNorm(vision_dim)
+        self.input_projection = nn.Linear(vision_dim, hidden_dim)
+        self.spatial_embedding = nn.Parameter(
+            torch.empty(tokens_per_frame, hidden_dim)
+        )
+        self.temporal_embedding = nn.Embedding(max_history_frames, hidden_dim)
+        self.query_tokens = nn.Parameter(torch.empty(num_queries, hidden_dim))
+        self.null_history_token = nn.Parameter(torch.empty(1, hidden_dim))
+
+        decoder_layer = nn.TransformerDecoderLayer(
+            d_model=hidden_dim,
+            nhead=num_heads,
+            dim_feedforward=ffn_dim,
+            dropout=dropout,
+            activation="gelu",
+            batch_first=True,
+            norm_first=True,
+        )
+        self.decoder = nn.TransformerDecoder(decoder_layer, num_layers=num_layers)
+        self.output_norm = nn.LayerNorm(hidden_dim)
+        self.output_projection = nn.Linear(hidden_dim, vision_dim)
+
+        nn.init.normal_(self.query_tokens, std=0.02)
+        nn.init.normal_(self.null_history_token, std=0.02)
+        nn.init.normal_(self.spatial_embedding, std=0.02)
+        nn.init.normal_(self.temporal_embedding.weight, std=0.02)
+
+    def forward(self, history):
+        """
+        Args:
+            history: EVA features shaped [batch, frames, 64, vision_dim].
+
+        Returns:
+            Fixed history tokens shaped [batch, num_queries, vision_dim].
+        """
+        if history.ndim != 4:
+            raise ValueError(
+                "history must have shape [batch, frames, tokens, vision_dim]"
+            )
+
+        batch_size, frame_count, token_count, vision_dim = history.shape
+        if token_count != self.tokens_per_frame:
+            raise ValueError(
+                f"expected {self.tokens_per_frame} tokens per frame, got {token_count}"
+            )
+        if vision_dim != self.vision_dim:
+            raise ValueError(f"expected vision_dim={self.vision_dim}, got {vision_dim}")
+
+        if frame_count == 0:
+            memory = self.null_history_token.view(1, 1, -1).expand(
+                batch_size, -1, -1
+            )
+        else:
+            memory = self.input_projection(self.input_norm(history))
+            relative_age = torch.arange(
+                frame_count - 1,
+                -1,
+                -1,
+                device=history.device,
+            ).clamp(max=self.max_history_frames - 1)
+            temporal_embedding = self.temporal_embedding(relative_age)
+            memory = (
+                memory
+                + self.spatial_embedding.view(1, 1, token_count, -1)
+                + temporal_embedding.view(1, frame_count, 1, -1)
+            )
+            memory = memory.flatten(1, 2)
+
+        queries = self.query_tokens.unsqueeze(0).expand(batch_size, -1, -1)
+        compressed = self.decoder(tgt=queries, memory=memory)
+        return self.output_projection(self.output_norm(compressed))
+
+
+def build_history_compressor(config):
+    compressor_type = getattr(config, "history_compressor_type", "heuristic")
+    if compressor_type != "cross_attention":
+        raise ValueError(f"Unsupported history compressor: {compressor_type}")
+
+    return LearnedHistoryCompressor(
+        vision_dim=config.mm_hidden_size,
+        hidden_dim=getattr(config, "history_hidden_size", 512),
+        num_queries=getattr(config, "history_num_queries", 64),
+        num_heads=getattr(config, "history_num_heads", 8),
+        num_layers=getattr(config, "history_num_layers", 2),
+        ffn_dim=getattr(config, "history_ffn_dim", 2048),
+        dropout=getattr(config, "history_dropout", 0.1),
+        max_history_frames=getattr(config, "history_max_frames", 512),
+    )

--- a/uninavid/model/history_compressor.py
+++ b/uninavid/model/history_compressor.py
@@ -16,6 +16,7 @@ class LearnedHistoryCompressor(nn.Module):
         dropout=0.1,
         tokens_per_frame=64,
         max_history_frames=512,
+        goal_dim=None,
     ):
         super().__init__()
         if hidden_dim % num_heads != 0:
@@ -27,6 +28,7 @@ class LearnedHistoryCompressor(nn.Module):
         self.tokens_per_frame = tokens_per_frame
         self.vision_dim = vision_dim
         self.max_history_frames = max_history_frames
+        self.goal_dim = goal_dim
 
         self.input_norm = nn.LayerNorm(vision_dim)
         self.input_projection = nn.Linear(vision_dim, hidden_dim)
@@ -34,6 +36,15 @@ class LearnedHistoryCompressor(nn.Module):
             torch.empty(tokens_per_frame, hidden_dim)
         )
         self.temporal_embedding = nn.Embedding(max_history_frames, hidden_dim)
+        if goal_dim is not None:
+            self.goal_projection = nn.Sequential(
+                nn.LayerNorm(goal_dim),
+                nn.Linear(goal_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, hidden_dim),
+            )
+        else:
+            self.goal_projection = None
         self.query_tokens = nn.Parameter(torch.empty(num_queries, hidden_dim))
         self.null_history_token = nn.Parameter(torch.empty(1, hidden_dim))
 
@@ -55,10 +66,12 @@ class LearnedHistoryCompressor(nn.Module):
         nn.init.normal_(self.spatial_embedding, std=0.02)
         nn.init.normal_(self.temporal_embedding.weight, std=0.02)
 
-    def forward(self, history):
+    def forward(self, history, goal_features=None, goal_attention_mask=None):
         """
         Args:
             history: EVA features shaped [batch, frames, 64, vision_dim].
+            goal_features: Frozen LLM embeddings shaped [batch, tokens, goal_dim].
+            goal_attention_mask: Valid goal tokens shaped [batch, tokens].
 
         Returns:
             Fixed history tokens shaped [batch, num_queries, vision_dim].
@@ -97,6 +110,15 @@ class LearnedHistoryCompressor(nn.Module):
             memory = memory.flatten(1, 2)
 
         queries = self.query_tokens.unsqueeze(0).expand(batch_size, -1, -1)
+        if self.goal_projection is not None:
+            if goal_features is None or goal_attention_mask is None:
+                raise ValueError("goal-conditioned compression requires goal features")
+            if goal_features.shape[0] != batch_size:
+                raise ValueError("goal batch size must match history batch size")
+            mask = goal_attention_mask.to(goal_features.dtype).unsqueeze(-1)
+            pooled_goal = (goal_features * mask).sum(dim=1)
+            pooled_goal = pooled_goal / mask.sum(dim=1).clamp_min(1)
+            queries = queries + self.goal_projection(pooled_goal).unsqueeze(1)
         compressed = self.decoder(tgt=queries, memory=memory)
         return self.output_projection(self.output_norm(compressed))
 
@@ -106,6 +128,7 @@ def build_history_compressor(config):
     if compressor_type != "cross_attention":
         raise ValueError(f"Unsupported history compressor: {compressor_type}")
 
+    goal_conditioned = getattr(config, "history_goal_conditioned", False)
     return LearnedHistoryCompressor(
         vision_dim=config.mm_hidden_size,
         hidden_dim=getattr(config, "history_hidden_size", 512),
@@ -115,4 +138,5 @@ def build_history_compressor(config):
         ffn_dim=getattr(config, "history_ffn_dim", 2048),
         dropout=getattr(config, "history_dropout", 0.1),
         max_history_frames=getattr(config, "history_max_frames", 512),
+        goal_dim=config.hidden_size if goal_conditioned else None,
     )

--- a/uninavid/model/language_model/llava_llama_vid.py
+++ b/uninavid/model/language_model/llava_llama_vid.py
@@ -68,6 +68,8 @@ class LlavaLlamaAttForCausalLM(LlamaForCausalLM, UniNaVIDMetaForCausalLM):
         output_hidden_states: Optional[bool] = None,
         images: Optional[torch.FloatTensor] = None,
         prompts: Optional[List[str]] = None,
+        goal_input_ids: Optional[torch.LongTensor] = None,
+        goal_attention_mask: Optional[torch.Tensor] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -82,7 +84,16 @@ class LlavaLlamaAttForCausalLM(LlamaForCausalLM, UniNaVIDMetaForCausalLM):
             if input_ids.device != self.device:
                 input_ids = input_ids.to(device=self.device)
 
-        input_ids, attention_mask, past_key_values, inputs_embeds, labels = self.prepare_inputs_labels_for_multimodal(input_ids, attention_mask, past_key_values, labels, images, prompts=prompts)
+        input_ids, attention_mask, past_key_values, inputs_embeds, labels = self.prepare_inputs_labels_for_multimodal(
+            input_ids,
+            attention_mask,
+            past_key_values,
+            labels,
+            images,
+            prompts=prompts,
+            goal_input_ids=goal_input_ids,
+            goal_attention_mask=goal_attention_mask,
+        )
 
         torch.cuda.empty_cache()
 

--- a/uninavid/model/uninavid_arch.py
+++ b/uninavid/model/uninavid_arch.py
@@ -27,6 +27,7 @@ import torch.nn.functional as F
 
 from .multimodal_encoder.builder import build_vision_tower
 from .multimodal_projector.builder import build_vision_projector
+from .history_compressor import build_history_compressor
 
 
 from uninavid.constants import IGNORE_INDEX, IMAGE_TOKEN_INDEX, DEFAULT_IMAGE_PATCH_TOKEN, DEFAULT_IM_START_TOKEN, DEFAULT_IM_END_TOKEN, VIDEO_START_SPECIAL_TOKEN, VIDEO_END_SPECIAL_TOKEN, IMAGE_START_TOKEN, IMAGE_END_TOKEN, NAVIGATION_SPECIAL_TOKEN, NAVIGATION_IDENTIFIER, IAMGE_SEPARATOR
@@ -42,6 +43,8 @@ class UniNaVIDMetaModel:
         if hasattr(config, "mm_vision_tower"):
             self.vision_tower = build_vision_tower(config, delay_load=True)
             self.mm_projector = build_vision_projector(config)
+            if getattr(config, "history_compressor_type", "heuristic") == "cross_attention":
+                self.history_compressor = build_history_compressor(config)
 
     def get_vision_tower(self):
         vision_tower = getattr(self, 'vision_tower', None)
@@ -68,6 +71,16 @@ class UniNaVIDMetaModel:
         self.config.image_processor = getattr(model_args, 'image_processor', None)
         self.config.compress_type = getattr(model_args, "compress_type", None)
         self.config.run_type = model_args.run_type
+        self.config.history_compressor_type = getattr(
+            model_args, "history_compressor_type", "heuristic"
+        )
+        self.config.history_num_queries = getattr(model_args, "history_num_queries", 64)
+        self.config.history_hidden_size = getattr(model_args, "history_hidden_size", 512)
+        self.config.history_num_heads = getattr(model_args, "history_num_heads", 8)
+        self.config.history_num_layers = getattr(model_args, "history_num_layers", 2)
+        self.config.history_ffn_dim = getattr(model_args, "history_ffn_dim", 2048)
+        self.config.history_dropout = getattr(model_args, "history_dropout", 0.1)
+        self.config.history_max_frames = getattr(model_args, "history_max_frames", 512)
         
         vision_tower = build_vision_tower(model_args)
 
@@ -89,6 +102,14 @@ class UniNaVIDMetaModel:
             # In case it is frozen by LoRA
             for p in self.mm_projector.parameters():
                 p.requires_grad = True
+
+        if self.config.history_compressor_type == "cross_attention":
+            if getattr(self, "history_compressor", None) is None:
+                self.history_compressor = build_history_compressor(self.config)
+        elif self.config.history_compressor_type != "heuristic":
+            raise ValueError(
+                f"Unsupported history compressor: {self.config.history_compressor_type}"
+            )
 
         if pretrain_mm_mlp_adapter is not None:
             mm_projector_weights = torch.load(pretrain_mm_mlp_adapter, map_location='cpu')
@@ -246,6 +267,9 @@ class UniNaVIDMetaForCausalLM(ABC):
 
     def vlm_attention(self, image_features, prompts=None, image_counts=None, long_video=False):
         compress_type = self.config.compress_type
+        history_compressor_type = getattr(
+            self.config, "history_compressor_type", "heuristic"
+        )
         compress_grid_sizes = {"grid:2": 4, "grid:4": 16, "mean": 1}
 
         nav_size = compress_grid_sizes.get(compress_type)
@@ -295,7 +319,14 @@ class UniNaVIDMetaForCausalLM(ABC):
                     final_token_nav = final_token_nav[None].expand(len(prompt), -1, -1, -1).flatten(1, 2)
                     assert final_token_nav.shape[0] == 1 and final_token_nav.shape[1] == 64 and final_token.shape[0] == 1
                     
-                    if self.config.run_type == "eval":
+                    if history_compressor_type == "cross_attention":
+                        if self.config.run_type == "eval":
+                            raise NotImplementedError(
+                                "Online cache inference is not implemented for the "
+                                "cross-attention history compressor"
+                            )
+                        lengths_list = [self.get_model().history_compressor.num_queries]
+                    elif self.config.run_type == "eval":
                         final_token, lengths_list = self.online_process_tensor(nav_size)
                         final_token = final_token.unsqueeze(0)
                     else:
@@ -354,10 +385,25 @@ class UniNaVIDMetaForCausalLM(ABC):
         if image_counts is None or (image_counts == 1 and not navigation):
             vis_embed = process_grid(vis_embed, 8)
         elif navigation:
-               
             vis_embed_nav = vis_embed[-1:]
             vis_embed_nav = process_grid(vis_embed_nav, 8)
-            vis_embed = process_grid(vis_embed, grid_size)
+
+            history_compressor_type = getattr(
+                self.config, "history_compressor_type", "heuristic"
+            )
+            if history_compressor_type == "cross_attention":
+                history = vis_embed[:-1]
+                if history.shape[0] == 0:
+                    history = vis_embed.new_empty((0, 64, vis_embed.shape[-1]))
+                else:
+                    history = process_grid(history, 8)
+                vis_embed = self.get_model().history_compressor(history.unsqueeze(0))
+            elif history_compressor_type == "heuristic":
+                vis_embed = process_grid(vis_embed, grid_size)
+            else:
+                raise ValueError(
+                    f"Unsupported history compressor: {history_compressor_type}"
+                )
         
         else:
             vis_embed = process_grid(vis_embed, grid_size)
@@ -694,5 +740,3 @@ class UniNaVIDMetaForCausalLM(ABC):
                     p.requires_grad = False
 
    
-
-

--- a/uninavid/model/uninavid_arch.py
+++ b/uninavid/model/uninavid_arch.py
@@ -81,6 +81,9 @@ class UniNaVIDMetaModel:
         self.config.history_ffn_dim = getattr(model_args, "history_ffn_dim", 2048)
         self.config.history_dropout = getattr(model_args, "history_dropout", 0.1)
         self.config.history_max_frames = getattr(model_args, "history_max_frames", 512)
+        self.config.history_goal_conditioned = getattr(
+            model_args, "history_goal_conditioned", False
+        )
         
         vision_tower = build_vision_tower(model_args)
 
@@ -248,7 +251,15 @@ class UniNaVIDMetaForCausalLM(ABC):
 
 
 
-    def encode_images(self, images, prompts=None, image_counts=None, long_video=False):
+    def encode_images(
+        self,
+        images,
+        prompts=None,
+        image_counts=None,
+        long_video=False,
+        goal_features=None,
+        goal_attention_mask=None,
+    ):
         if long_video:
             # use pre-computed features
             image_features = images
@@ -260,12 +271,22 @@ class UniNaVIDMetaForCausalLM(ABC):
         image_features, video_or_not, nav_or_not, final_token_length_lst = self.vlm_attention(image_features,
                                                                                               prompts=prompts,
                                                                                               image_counts=image_counts,
-                                                                                              long_video=long_video)
+                                                                                              long_video=long_video,
+                                                                                              goal_features=goal_features,
+                                                                                              goal_attention_mask=goal_attention_mask)
         return image_features, video_or_not, nav_or_not, final_token_length_lst
 
     
 
-    def vlm_attention(self, image_features, prompts=None, image_counts=None, long_video=False):
+    def vlm_attention(
+        self,
+        image_features,
+        prompts=None,
+        image_counts=None,
+        long_video=False,
+        goal_features=None,
+        goal_attention_mask=None,
+    ):
         compress_type = self.config.compress_type
         history_compressor_type = getattr(
             self.config, "history_compressor_type", "heuristic"
@@ -307,7 +328,15 @@ class UniNaVIDMetaForCausalLM(ABC):
             final_token, final_token_nav = self.token_generation(
                 img_feat_prompt,
                 image_counts=None if image_counts is None else image_counts[_idx],
-                navigation=is_navigation
+                navigation=is_navigation,
+                goal_features=(
+                    None if goal_features is None else goal_features[_idx:_idx + 1]
+                ),
+                goal_attention_mask=(
+                    None
+                    if goal_attention_mask is None
+                    else goal_attention_mask[_idx:_idx + 1]
+                ),
             )
 
             if is_navigation and final_token_nav is None:
@@ -363,7 +392,14 @@ class UniNaVIDMetaForCausalLM(ABC):
 
 
 
-    def token_generation(self, vis_embed, image_counts=None, navigation=False):
+    def token_generation(
+        self,
+        vis_embed,
+        image_counts=None,
+        navigation=False,
+        goal_features=None,
+        goal_attention_mask=None,
+    ):
         
                                 
         def process_grid(vis_embed, grid_size):
@@ -397,7 +433,11 @@ class UniNaVIDMetaForCausalLM(ABC):
                     history = vis_embed.new_empty((0, 64, vis_embed.shape[-1]))
                 else:
                     history = process_grid(history, 8)
-                vis_embed = self.get_model().history_compressor(history.unsqueeze(0))
+                vis_embed = self.get_model().history_compressor(
+                    history.unsqueeze(0),
+                    goal_features=goal_features,
+                    goal_attention_mask=goal_attention_mask,
+                )
             elif history_compressor_type == "heuristic":
                 vis_embed = process_grid(vis_embed, grid_size)
             else:
@@ -426,8 +466,17 @@ class UniNaVIDMetaForCausalLM(ABC):
         self.prompts = prompts
 
 
-    def prepare_inputs_labels_for_multimodal(self, input_ids, attention_mask, past_key_values, labels, images,
-                                             prompts=None):
+    def prepare_inputs_labels_for_multimodal(
+        self,
+        input_ids,
+        attention_mask,
+        past_key_values,
+        labels,
+        images,
+        prompts=None,
+        goal_input_ids=None,
+        goal_attention_mask=None,
+    ):
         if 'grid' in self.config.compress_type:
             grid_size = int(self.config.compress_type.split('grid:')[-1])
             if grid_size == 2:
@@ -453,6 +502,9 @@ class UniNaVIDMetaForCausalLM(ABC):
             return input_ids, attention_mask, past_key_values, None, labels
 
         long_video = False
+        goal_features = None
+        if goal_input_ids is not None:
+            goal_features = self.get_model().embed_tokens(goal_input_ids).detach()
 
         if type(images) is list or images.ndim == 5:
             # not reseshape for long video
@@ -462,10 +514,14 @@ class UniNaVIDMetaForCausalLM(ABC):
             concat_images = torch.cat(images, dim=0)
             image_features, video_or_not, nav_or_not, final_token_length_lst = self.encode_images(concat_images,
                                                                                                   prompts, image_counts,
-                                                                                                  long_video=long_video)
+                                                                                                  long_video=long_video,
+                                                                                                  goal_features=goal_features,
+                                                                                                  goal_attention_mask=goal_attention_mask)
         else:
             image_features, video_or_not, nav_or_not, final_token_length_lst = self.encode_images(images, prompts,
-                                                                                                  long_video=long_video)
+                                                                                                  long_video=long_video,
+                                                                                                  goal_features=goal_features,
+                                                                                                  goal_attention_mask=goal_attention_mask)
 
         new_input_embeds = []
         new_labels = [] if labels is not None else None

--- a/uninavid/train/train.py
+++ b/uninavid/train/train.py
@@ -122,6 +122,15 @@ class ModelArguments:
     mm_use_im_patch_token: bool = field(default=True)
     mm_vision_select_feature: Optional[str] = field(default="patch")
     compress_type: Optional[str] = field(default=None)
+    history_compressor_type: str = field(default="heuristic")
+    history_num_queries: int = field(default=64)
+    history_hidden_size: int = field(default=512)
+    history_num_heads: int = field(default=8)
+    history_num_layers: int = field(default=2)
+    history_ffn_dim: int = field(default=2048)
+    history_dropout: float = field(default=0.1)
+    history_max_frames: int = field(default=512)
+    tune_history_compressor: bool = field(default=False)
     run_type: Optional[str] = field(default="train") # train / eval
 
 @dataclass
@@ -233,7 +242,10 @@ def get_mm_adapter_state_maybe_zero_3(named_params, keys_to_match):
 def find_all_linear_names(model):
     cls = torch.nn.Linear
     lora_module_names = set()
-    multimodal_keywords = ['mm_projector', 'vision_tower', 'vision_resampler', 'vlm_att']
+    multimodal_keywords = [
+        'mm_projector', 'vision_tower', 'vision_resampler', 'vlm_att',
+        'history_compressor',
+    ]
     for name, module in model.named_modules():
         if any(mm_keyword in name for mm_keyword in multimodal_keywords):
             continue
@@ -250,10 +262,16 @@ def find_all_linear_names(model):
 def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: str):
     """Collects the state dict and dump to disk."""
 
-    if getattr(trainer.args, "tune_mm_mlp_adapter", False):
-        # Only save Adapter
-        # keys_to_match = ['mm_projector']
-        keys_to_match = ['mm_projector', 'vision_resampler', 'vlm_att']
+    tune_mm_adapter = getattr(trainer.args, "tune_mm_mlp_adapter", False)
+    tune_history_compressor = getattr(
+        trainer.args, "tune_history_compressor", False
+    )
+    if tune_mm_adapter or tune_history_compressor:
+        keys_to_match = []
+        if tune_mm_adapter:
+            keys_to_match.extend(['mm_projector', 'vision_resampler', 'vlm_att'])
+        if tune_history_compressor:
+            keys_to_match.append('history_compressor')
         if getattr(trainer.args, "use_im_start_end", False):
             keys_to_match.extend(['embed_tokens', 'embed_in'])
 
@@ -268,7 +286,13 @@ def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: st
                 os.makedirs(mm_projector_folder, exist_ok=True)
                 torch.save(weight_to_save, os.path.join(mm_projector_folder, f'{current_folder}.bin'))
             else:
-                torch.save(weight_to_save, os.path.join(output_dir, f'mm_projector.bin'))
+                if tune_mm_adapter and tune_history_compressor:
+                    filename = 'multimodal_adapters.bin'
+                elif tune_history_compressor:
+                    filename = 'history_compressor.bin'
+                else:
+                    filename = 'mm_projector.bin'
+                torch.save(weight_to_save, os.path.join(output_dir, filename))
         return
 
     if trainer.deepspeed:
@@ -1337,6 +1361,25 @@ def train():
             model.requires_grad_(False)
             for p in model.get_model().mm_projector.parameters():
                 p.requires_grad = True
+
+        model.config.tune_history_compressor = (
+            training_args.tune_history_compressor
+        ) = model_args.tune_history_compressor
+        if model_args.tune_history_compressor:
+            if model_args.history_compressor_type != "cross_attention":
+                raise ValueError(
+                    "--tune_history_compressor requires "
+                    "--history_compressor_type cross_attention"
+                )
+            if not model_args.tune_mm_mlp_adapter:
+                model.requires_grad_(False)
+            model.get_model().history_compressor.requires_grad_(True)
+
+        if model_args.history_compressor_type == "cross_attention":
+            model.get_model().history_compressor.to(
+                dtype=compute_dtype,
+                device=training_args.device,
+            )
 
         model.config.freeze_mm_mlp_adapter = training_args.freeze_mm_mlp_adapter
         if training_args.freeze_mm_mlp_adapter:

--- a/uninavid/train/train.py
+++ b/uninavid/train/train.py
@@ -130,6 +130,7 @@ class ModelArguments:
     history_ffn_dim: int = field(default=2048)
     history_dropout: float = field(default=0.1)
     history_max_frames: int = field(default=512)
+    history_goal_conditioned: bool = field(default=False)
     tune_history_compressor: bool = field(default=False)
     run_type: Optional[str] = field(default="train") # train / eval
 
@@ -147,6 +148,7 @@ class DataArguments:
     image_grid_pinpoints: Optional[str] = field(default=None)
     input_prompt: Optional[str] = field(default=None)
     refine_prompt: Optional[bool] = field(default=False)
+    video_augmentation: bool = field(default=True)
 
 
 @dataclass
@@ -1086,7 +1088,11 @@ class LazySupervisedDataset(Dataset):
                         sample_fps = round(vr.get_avg_fps()/self.data_args.video_fps)
                         frame_idx = [i for i in range(0, len(vr), sample_fps)]
                         video = vr.get_batch(frame_idx).asnumpy()
-                        if  "NAV_ID" in self.list_data_dict[i]['id'] and len(frame_idx) > 1: # TODO: temp fix for nav
+                        if (
+                            "NAV_ID" in self.list_data_dict[i]['id']
+                            and len(frame_idx) > 1
+                            and self.data_args.video_augmentation
+                        ):
                             assert len(video) > 1
                             
                             last_frame_index = len(video) - 1                           
@@ -1142,6 +1148,16 @@ class LazySupervisedDataset(Dataset):
             prompt = data_dict['prompt']
         else:
             prompt = None
+
+        goal_text = self.list_data_dict[i].get("instruction")
+        if goal_text is None and "goal" in self.list_data_dict[i]:
+            goal_text = f"Search for a {self.list_data_dict[i]['goal']}."
+        if goal_text is not None:
+            goal_tokens = self.tokenizer(
+                goal_text,
+                return_tensors="pt",
+                add_special_tokens=True,
+            )
         
         if suffix == 'pkl':
             prompt = [query_prompt]
@@ -1163,6 +1179,9 @@ class LazySupervisedDataset(Dataset):
         # prompt exist in the data
         if prompt is not None:
             data_dict['prompt'] = prompt
+        if goal_text is not None:
+            data_dict['goal_input_ids'] = goal_tokens.input_ids[0]
+            data_dict['goal_attention_mask'] = goal_tokens.attention_mask[0]
 
         return data_dict
 
@@ -1202,6 +1221,18 @@ class DataCollatorForSupervisedDataset(object):
 
         if 'prompt' in instances[0]:
             batch['prompts'] = [instance['prompt'] for instance in instances]
+
+        if 'goal_input_ids' in instances[0]:
+            batch['goal_input_ids'] = torch.nn.utils.rnn.pad_sequence(
+                [instance['goal_input_ids'] for instance in instances],
+                batch_first=True,
+                padding_value=self.tokenizer.pad_token_id,
+            )
+            batch['goal_attention_mask'] = torch.nn.utils.rnn.pad_sequence(
+                [instance['goal_attention_mask'] for instance in instances],
+                batch_first=True,
+                padding_value=0,
+            )
 
         return batch
 

--- a/uninavid/train/train.py
+++ b/uninavid/train/train.py
@@ -993,6 +993,8 @@ class LazySupervisedDataset(Dataset):
 
     def __getitem__(self, i) -> Dict[str, torch.Tensor]:
         attempt, max_attempt = 0, 10
+        requested_index = i
+        last_error = None
         while attempt < max_attempt:
             try:
                 sources = self.list_data_dict[i]
@@ -1089,10 +1091,18 @@ class LazySupervisedDataset(Dataset):
                     sources = copy.deepcopy([e["conversations"] for e in sources])
                 
                 break
-            except:
+            except Exception as exc:
+                last_error = exc
                 attempt += 1
-                print(f"Error in loading {i}, retrying...")
+                print(
+                    f"Error in loading {i} ({type(exc).__name__}: {exc}), "
+                    f"retrying..."
+                )
                 i = random.randint(0, len(self.list_data_dict)-1)
+        else:
+            raise RuntimeError(
+                f"Failed to load dataset item {requested_index} after {max_attempt} attempts"
+            ) from last_error
                 
 
         has_image = ('image' in self.list_data_dict[i]) or ('video' in self.list_data_dict[i])
@@ -1393,4 +1403,3 @@ def train():
 
 if __name__ == "__main__":
     train()
-


### PR DESCRIPTION
## Summary

- add a learned goal-conditioned Cross-Attention history compressor
- add Task 4 smoke, overfit, and evaluation tooling
- record controlled comparisons for compressor depth and multimodal-projector learning rates
- use a lower projector learning rate to preserve the pretrained visual interface

## Result

On the 200-sample teacher-forced overfit diagnostic, the separate learning-rate run reached 77.5% mean action accuracy and 41.0% four-action exact match, compared with 62.625% and 17.0% for the heuristic baseline. This is a training-set diagnostic, not a held-out generalization result.

## Validation

- `bash -n scripts/task4_overfit_200_goal.sh`
- `git diff --check`
- `.venv/bin/python -m unittest tests.test_history_compressor -v` (8 tests passed)
- 200-sample teacher-forced evaluation completed